### PR TITLE
fix: unblock uvx feather-etl validate against real SQL Server (closes #1, #2, #3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "typer>=0.9",
     "pyodbc>=5.0",
     "psycopg2-binary>=2.9",
+    "python-dotenv>=1.0",
     "pytz",  # not imported directly, but DuckDB needs it for timestamp→Python conversion
 ]
 

--- a/src/feather_etl/cli.py
+++ b/src/feather_etl/cli.py
@@ -105,6 +105,9 @@ def validate(ctx: typer.Context, config: Path = typer.Option("feather.yaml", "--
 
     if not source_ok:
         typer.echo("Source connection failed.", err=True)
+        err = getattr(source, "_last_error", None)
+        if err:
+            typer.echo(f"  Details: {err}", err=True)
         raise typer.Exit(code=2)
 
 

--- a/src/feather_etl/config.py
+++ b/src/feather_etl/config.py
@@ -19,10 +19,19 @@ _SQL_IDENTIFIER_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _UNRESOLVED_ENV_RE = re.compile(r"\$\{([^}]+)\}")
 
 
+# Default connection-string templates for database sources.
+#
+# SQL Server note: ODBC Driver 18 enforces TLS certificate validation by
+# default, so connections to servers with self-signed or internally-issued
+# certs fail with "SSL Provider: certificate verify failed". We default to
+# TrustServerCertificate=yes because most on-prem ERP SQL Servers ship with
+# self-signed certs. Users whose server presents a publicly-trusted cert can
+# override by providing a raw `connection_string:` in feather.yaml.
 DB_CONNECTION_BUILDERS: dict[str, str] = {
     "sqlserver": (
         "DRIVER={{ODBC Driver 18 for SQL Server}};"
-        "SERVER={host},{port};DATABASE={database};UID={user};PWD={password}"
+        "SERVER={host},{port};DATABASE={database};UID={user};PWD={password};"
+        "TrustServerCertificate=yes"
     ),
     "postgres": (
         "host={host} port={port} dbname={database} user={user} password={password}"

--- a/src/feather_etl/config.py
+++ b/src/feather_etl/config.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import yaml
+from dotenv import load_dotenv
 
 FILE_SOURCE_TYPES = {"duckdb", "sqlite", "csv", "excel", "json"}
 VALID_STRATEGIES = {"full", "incremental", "append"}
@@ -307,6 +308,16 @@ def load_config(
     Mode resolution: mode_override (CLI) > FEATHER_MODE env var > YAML mode > default "dev".
     """
     config_dir = config_path.parent.resolve()
+
+    # Auto-load .env from the config directory so users don't have to
+    # manually export variables before running feather commands (closes #1).
+    # override=False respects any variables the user already exported in
+    # their shell, which is important for CI/CD where secrets come from
+    # the environment, not a committed .env file.
+    dotenv_path = config_dir / ".env"
+    if dotenv_path.is_file():
+        load_dotenv(dotenv_path, override=False)
+
     raw = yaml.safe_load(config_path.read_text())
     raw = _resolve_yaml_env_vars(raw)
 

--- a/src/feather_etl/sources/postgres.py
+++ b/src/feather_etl/sources/postgres.py
@@ -70,15 +70,18 @@ class PostgresSource(DatabaseSource):
     def __init__(self, connection_string: str, batch_size: int = 120_000) -> None:
         super().__init__(connection_string)
         self.batch_size = batch_size
+        self._last_error: str | None = None
 
     # _format_watermark: uses base class default (ISO value passed through unchanged)
 
     def check(self) -> bool:
+        self._last_error = None
         try:
             conn = psycopg2.connect(self.connection_string, connect_timeout=10)
             conn.close()
             return True
-        except psycopg2.Error:
+        except psycopg2.Error as e:
+            self._last_error = str(e)
             return False
 
     def discover(self) -> list[StreamSchema]:

--- a/src/feather_etl/sources/sqlserver.py
+++ b/src/feather_etl/sources/sqlserver.py
@@ -71,6 +71,7 @@ class SqlServerSource(DatabaseSource):
     def __init__(self, connection_string: str, batch_size: int = 120_000) -> None:
         super().__init__(connection_string)
         self.batch_size = batch_size
+        self._last_error: str | None = None
 
     def _format_watermark(self, value: str) -> str:
         """SQL Server datetime: replace ISO 'T' separator, truncate to 3ms precision."""
@@ -81,11 +82,13 @@ class SqlServerSource(DatabaseSource):
         return wm_val
 
     def check(self) -> bool:
+        self._last_error = None
         try:
             con = pyodbc.connect(self.connection_string, timeout=10)
             con.close()
             return True
-        except pyodbc.Error:
+        except pyodbc.Error as e:
+            self._last_error = str(e)
             return False
 
     def discover(self) -> list[StreamSchema]:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,40 @@ class TestValidate:
         assert result.exit_code != 0
         assert "Config file not found" in result.output
 
+    def test_validate_prints_details_on_source_failure(
+        self, cli_env: tuple[Path, Path], monkeypatch
+    ):
+        """When source.check() fails, the real exception must be surfaced as 'Details: ...'.
+
+        Regression for siraj-samsudeen/feather-etl#2: the CLI used to print only
+        'Source connection failed.' and swallow the real error, making remote DB
+        misconfig (TLS, creds, driver) impossible to diagnose without code changes.
+        """
+        from feather_etl.cli import app
+
+        class FakeFailingSource:
+            def __init__(self):
+                self._last_error = "TLS Provider: certificate verify failed"
+
+            def check(self) -> bool:
+                return False
+
+        def fake_create_source(_source_cfg):
+            return FakeFailingSource()
+
+        monkeypatch.setattr(
+            "feather_etl.sources.registry.create_source", fake_create_source
+        )
+
+        config_path, _ = cli_env
+        result = runner.invoke(
+            app, ["validate", "--config", str(config_path)], catch_exceptions=False
+        )
+        assert result.exit_code == 2
+        # Typer's CliRunner merges stderr into output by default.
+        assert "Source connection failed." in result.output
+        assert "Details: TLS Provider: certificate verify failed" in result.output
+
     def test_validate_shows_state_path(self, cli_env: tuple[Path, Path]):
         """UX-9: validate output should show where the state DB will be created."""
         from feather_etl.cli import app

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,6 +206,80 @@ class TestEnvVarEdgeCases:
         assert result.defaults.overlap_window_minutes == 5
         assert result.defaults.batch_size == 50000
 
+    def test_dotenv_auto_loaded_from_config_dir(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Regression for siraj-samsudeen/feather-etl#1.
+
+        A `.env` file next to `feather.yaml` should be loaded automatically,
+        so users don't have to manually `export` variables before running
+        `feather validate`, `feather run`, etc. Without this, `${VAR}`
+        references in feather.yaml fall back to `os.environ` only.
+        """
+        from feather_etl.config import load_config
+
+        # Ensure the var is NOT already in the environment
+        monkeypatch.delenv("FEATHER_TEST_DOTENV_VAR", raising=False)
+
+        db = tmp_path / "source.duckdb"
+        db.touch()
+
+        # Write .env alongside the config — this is what should get auto-loaded
+        (tmp_path / ".env").write_text("FEATHER_TEST_DOTENV_VAR=bronze\n")
+
+        cfg = {
+            "source": {"type": "duckdb", "path": str(db)},
+            "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+            "tables": [
+                {
+                    "name": "t",
+                    "source_table": "main.t",
+                    "target_table": "${FEATHER_TEST_DOTENV_VAR}.t",
+                    "strategy": "full",
+                },
+            ],
+        }
+        config_file = _write_config(tmp_path, cfg)
+
+        result = load_config(config_file)
+        # If .env was loaded, ${FEATHER_TEST_DOTENV_VAR} resolved to "bronze"
+        assert result.tables[0].target_table == "bronze.t"
+
+    def test_dotenv_does_not_override_existing_env(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Existing shell/CI env vars must win over .env (override=False).
+
+        Important for CI/CD: secrets come from the environment, not a
+        committed .env file. A stray committed .env must not silently
+        clobber what the pipeline passes in.
+        """
+        from feather_etl.config import load_config
+
+        # Shell/CI already set this — should win
+        monkeypatch.setenv("FEATHER_TEST_OVERRIDE_VAR", "gold")
+
+        db = tmp_path / "source.duckdb"
+        db.touch()
+        (tmp_path / ".env").write_text("FEATHER_TEST_OVERRIDE_VAR=bronze\n")
+
+        cfg = {
+            "source": {"type": "duckdb", "path": str(db)},
+            "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+            "tables": [
+                {
+                    "name": "t",
+                    "source_table": "main.t",
+                    "target_table": "${FEATHER_TEST_OVERRIDE_VAR}.t",
+                    "strategy": "full",
+                },
+            ],
+        }
+        config_file = _write_config(tmp_path, cfg)
+
+        result = load_config(config_file)
+        assert result.tables[0].target_table == "gold.t"
+
     def test_unresolved_env_var_gives_clear_error(self, tmp_path: Path):
         """UX-4: Unset env vars should show which variable is missing."""
         from feather_etl.config import load_config

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -118,6 +118,44 @@ class TestPostgresSourceUnit:
 
 
 # ---------------------------------------------------------------------------
+# PostgresSource.check() — unit tests (mocked psycopg2)
+# ---------------------------------------------------------------------------
+
+
+class TestPostgresCheckLastError:
+    """check() must capture the real exception on failure so the CLI can print it."""
+
+    def test_check_failure_populates_last_error(self, monkeypatch):
+        from feather_etl.sources import postgres as pg_mod
+        from feather_etl.sources.postgres import PostgresSource
+
+        def boom(*args, **kwargs):
+            raise pg_mod.psycopg2.Error("FATAL: password authentication failed")
+
+        monkeypatch.setattr(pg_mod.psycopg2, "connect", boom)
+
+        src = PostgresSource("dbname=nope host=nope")
+        assert src.check() is False
+        assert src._last_error is not None
+        assert "password authentication failed" in src._last_error
+
+    def test_check_success_clears_last_error(self, monkeypatch):
+        from feather_etl.sources import postgres as pg_mod
+        from feather_etl.sources.postgres import PostgresSource
+
+        src = PostgresSource("dbname=x host=y")
+        src._last_error = "stale error from a prior call"
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(pg_mod.psycopg2, "connect", lambda *a, **k: FakeConn())
+        assert src.check() is True
+        assert src._last_error is None
+
+
+# ---------------------------------------------------------------------------
 # PostgresSource — integration tests (real PostgreSQL required)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sqlserver.py
+++ b/tests/test_sqlserver.py
@@ -348,6 +348,41 @@ def test_registry_creates_sqlserver_source() -> None:
 
 
 @pytest.mark.unit
+def test_sqlserver_connection_string_builder_trusts_self_signed_cert(tmp_path) -> None:
+    """Regression for siraj-samsudeen/feather-etl#3.
+
+    Driver 18 enforces strict TLS validation by default, so connecting to a
+    SQL Server with a self-signed cert fails with "certificate verify failed".
+    The default connection-string builder must include TrustServerCertificate=yes
+    so that on-prem ERP servers work out of the box. Users who want strict TLS
+    can override by providing a raw `connection_string:` in feather.yaml.
+    """
+    config_yaml = tmp_path / "feather.yaml"
+    config_yaml.write_text(
+        "source:\n"
+        "  type: sqlserver\n"
+        "  host: 10.0.0.1\n"
+        "  port: 1433\n"
+        "  database: mydb\n"
+        "  user: sa\n"
+        "  password: secret\n"
+        "destination:\n"
+        f"  path: {tmp_path}/dest.duckdb\n"
+        "tables:\n"
+        "  - name: orders\n"
+        "    source_table: dbo.orders\n"
+        "    strategy: full\n"
+        "    target_table: bronze.orders\n"
+    )
+    from feather_etl.config import load_config
+
+    cfg = load_config(config_yaml)
+    assert cfg.source.connection_string is not None
+    assert "TrustServerCertificate=yes" in cfg.source.connection_string
+    assert "ODBC Driver 18 for SQL Server" in cfg.source.connection_string
+
+
+@pytest.mark.unit
 def test_config_validation_sqlserver_requires_connection_string(tmp_path) -> None:
     """Config validation rejects sqlserver without connection_string."""
     config_yaml = tmp_path / "feather.yaml"

--- a/tests/test_sqlserver.py
+++ b/tests/test_sqlserver.py
@@ -307,11 +307,32 @@ def test_sqlserver_check_success(
 def test_sqlserver_connection_failure(
     mock_pyodbc: MagicMock, source: SqlServerSource
 ) -> None:
-    """check() returns False when connection fails."""
+    """check() returns False when connection fails and populates _last_error."""
     mock_pyodbc.Error = Exception
     mock_pyodbc.connect.side_effect = Exception("Connection refused")
 
     assert source.check() is False
+    assert source._last_error is not None
+    assert "Connection refused" in source._last_error
+
+
+@pytest.mark.unit
+@patch("feather_etl.sources.sqlserver.pyodbc")
+def test_sqlserver_check_success_clears_last_error(
+    mock_pyodbc: MagicMock, source: SqlServerSource
+) -> None:
+    """A successful check() resets _last_error left over from a prior failure."""
+    mock_pyodbc.Error = Exception
+    # First: fail
+    mock_pyodbc.connect.side_effect = Exception("boom")
+    assert source.check() is False
+    assert source._last_error is not None
+
+    # Then: succeed — _last_error should be cleared
+    mock_pyodbc.connect.side_effect = None
+    mock_pyodbc.connect.return_value = MagicMock()
+    assert source.check() is True
+    assert source._last_error is None
 
 
 # --- registry + config integration ---

--- a/uv.lock
+++ b/uv.lock
@@ -213,6 +213,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pyarrow" },
     { name = "pyodbc" },
+    { name = "python-dotenv" },
     { name = "pytz" },
     { name = "pyyaml" },
     { name = "typer" },
@@ -230,6 +231,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pyarrow", specifier = ">=15.0" },
     { name = "pyodbc", specifier = ">=5.0" },
+    { name = "python-dotenv", specifier = ">=1.0" },
     { name = "pytz" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "typer", specifier = ">=0.9" },
@@ -510,6 +512,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ships three related fixes uncovered while debugging `uvx feather-etl validate` against a real on-prem SQL Server (DBeaver connected fine with the same creds; feather-etl failed silently). Each issue is addressed in its own commit so they can be reviewed — and reverted — independently.

- **Closes #2** — `SqlServerSource.check()` and `PostgresSource.check()` used to swallow their driver's exception and leave the CLI with nothing to print but `Source connection failed.`, making remote DB misconfig impossible to diagnose without editing source. Now the real error is captured on `self._last_error` and printed by the validate handler as a `Details:` line. (Commit: `fix: surface real error on source connection failure`)

- **Closes #3** — ODBC Driver 18 enforces strict TLS certificate validation by default, so connecting to a SQL Server with a self-signed cert (the default posture of most on-prem ERP deployments) fails with `SSL Provider: certificate verify failed`. The default `sqlserver` connection-string template in `DB_CONNECTION_BUILDERS` now appends `TrustServerCertificate=yes`, with an inline comment explaining why and how to opt out (users who need strict TLS can provide a raw `connection_string:` in `feather.yaml`). (Commit: `fix: default TrustServerCertificate=yes for SQL Server Driver 18`)

- **Closes #1** — `load_config()` relied on `os.path.expandvars()`, so users with a `.env` next to `feather.yaml` had to manually `set -a && . ./.env && set +a && feather ...` before every command. Added `python-dotenv` and call `load_dotenv(<config_dir>/.env, override=False)` at the top of `load_config()`. `override=False` means shell- or CI-injected secrets still win over a committed `.env`. (Commit: `fix: auto-load .env files from config directory`)

## End-to-end proof

With all three fixes in place, a fresh shell against the real failing SQL Server (self-signed cert, env vars only in `.env`):

```bash
env -i HOME=\$HOME PATH=\$PATH uv run feather validate \\
    --config /path/to/client/feather.yaml
```

```
Config valid: 1 table(s)
  Source: sqlserver (20.235.28.10) — connected
  ...
```

Without any of the three fixes: `Source: sqlserver (20.235.28.10) — FAILED` with no diagnostic info. Each fix is individually necessary:
- Without #1, `\${SQLSERVER_*}` stays unresolved and load_config raises.
- Without #3, Driver 18 rejects the self-signed cert.
- Without #2, you cannot see which of the above is the actual cause.

## Test plan

- [x] `uv run pytest -q` — 428 passed, 14 skipped (was 421/14 before this PR; +7 new tests covering `_last_error` on sqlserver/postgres, CLI Details output, TrustServerCertificate builder, .env auto-load, and .env override precedence)
- [x] `bash scripts/hands_on_test.sh` — 66 passed, 0 failed
- [x] Manual E2E against real SQL Server with self-signed cert — validate now connects out of the box from a clean env

## Notes for review

- The `_last_error` attribute is an optional convention read via `getattr` — the `Source` Protocol is untouched, so file sources (`csv`, `duckdb`, `sqlite`, …) require no changes.
- `TrustServerCertificate=yes` only applies when users use the `host:/port:/database:/user:/password:` fields. A raw `connection_string:` in `feather.yaml` is still passed through untouched, so security-conscious users keep full control.
- `python-dotenv` is a tiny (~3 KB wheel) dependency with no transitive deps beyond stdlib; seemed worth it for the UX win versus hand-rolling `.env` parsing.