### PR TITLE
docs: clarify install path in README (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,7 @@ All three strategies are idempotent — safe to re-run after partial failures.
 
 ## This Repo vs Client Projects
 
-**feather-etl** (this repo) is a Python package only — no client config, no client data. Install it as a dependency:
-
-```bash
-uv add feather-etl
-```
+**feather-etl** (this repo) is a Python package only — no client config, no client data. See [Installation](#installation) for install options.
 
 Each client lives in its own GitHub repository, scaffolded with `feather init`:
 
@@ -98,6 +94,47 @@ feather init client-abc
 # → creates client-abc/ with feather.yaml, pyproject.toml, .gitignore, .env.example
 # → creates transforms/silver/, transforms/gold/, tables/, extracts/ directories
 ```
+
+## Installation
+
+> The PyPI package is named `feather-etl`; the installed command is `feather`.
+
+### Recommended — global CLI tool
+
+For most users (scaffolding clients, running pipelines locally), install feather-etl as a global `uv` tool:
+
+```bash
+uv tool install feather-etl
+feather --help
+```
+
+Upgrade or pin to a specific version:
+
+```bash
+uv tool upgrade feather-etl
+uv tool install feather-etl@X.Y.Z
+```
+
+### Alternative — project dependency
+
+For teams that need per-project version pinning or reproducibility, add feather-etl to a client project's `pyproject.toml`:
+
+```bash
+uv add feather-etl
+uv run feather --help
+```
+
+Every command then runs via `uv run feather …`.
+
+### One-off — no install
+
+To scaffold a new client without installing anything first:
+
+```bash
+uvx feather-etl init client-abc
+```
+
+`uvx` runs feather-etl in a throwaway environment — useful for the very first `init`, but it does **not** leave `feather` on your PATH. Pick one of the install options above before running `feather run`, `feather validate`, etc.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -128,13 +128,15 @@ Every command then runs via `uv run feather …`.
 
 ### One-off — no install
 
-To scaffold a new client without installing anything first:
+Run any feather command without installing, using `uvx`:
 
 ```bash
-uvx feather-etl init client-abc
+uvx feather-etl init client-abc     # scaffold a new client
+uvx feather-etl validate            # validate a config
+uvx feather-etl run                 # run the pipeline
 ```
 
-`uvx` runs feather-etl in a throwaway environment — useful for the very first `init`, but it does **not** leave `feather` on your PATH. Pick one of the install options above before running `feather run`, `feather validate`, etc.
+`uvx` downloads feather-etl into a throwaway environment for each invocation, so nothing is left on your PATH and there's no `feather` command afterwards — every call must be prefixed with `uvx feather-etl …`. Good for CI, quick trials, and scaffolding the very first client. For day-to-day use, prefer the global install above.
 
 ## CLI
 


### PR DESCRIPTION
## Summary

Fixes #11 — docs-only.

- Add a new `## Installation` section before `## CLI` with three clearly labelled options:
  1. **Recommended — global CLI tool:** `uv tool install feather-etl` → use `feather` directly. Includes upgrade path and version pinning.
  2. **Alternative — project dependency:** `uv add feather-etl` + `uv run feather …`.
  3. **One-off — no install:** `uvx feather-etl init` for scaffolding, with an explicit note that `uvx` does **not** leave `feather` on PATH.
- Add a one-line disambiguation at the top of the section: *"The PyPI package is named `feather-etl`; the installed command is `feather`."*
- Update `## This Repo vs Client Projects` to link to `## Installation` instead of hard-coding `uv add feather-etl` as the only path.

Out of scope per the issue: changing the scaffolder to omit `feather-etl` from the generated `pyproject.toml`.

## Test plan

- [x] README renders correctly (visual scan)
- [x] Internal anchor `#installation` resolves
- [ ] Reviewer reads the three options and confirms ordering matches the 90%/teams/one-off framing in issue #11