### PR TITLE
feat: add MySQL source type (#25)

### DIFF
--- a/docs/plans/2026-04-18-mysql-source-impl.md
+++ b/docs/plans/2026-04-18-mysql-source-impl.md
@@ -1,0 +1,1150 @@
+# MySQL Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `mysql` source type to feather-etl that extracts tables from MySQL databases into DuckDB, following the established Postgres/SQL Server pattern.
+
+**Architecture:** New `MySQLSource` class extends `DatabaseSource`, implements the full `Source` protocol. Uses `mysql-connector-python` for connectivity. Registered in the lazy-import registry so the dependency is only loaded when a MySQL source is configured.
+
+**Tech Stack:** `mysql-connector-python>=8.0`, PyArrow, DuckDB (test fixtures)
+
+**Spec:** `docs/plans/2026-04-18-mysql-source.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/feather_etl/sources/mysql.py` | **New.** `MySQLSource` class — config parsing, connectivity, discovery, extraction, change detection |
+| `src/feather_etl/sources/registry.py` | **Modify (1 line).** Add `"mysql"` → lazy import entry |
+| `pyproject.toml` | **Modify (1 line).** Add `mysql-connector-python` dependency |
+| `tests/test_mysql.py` | **New.** Unit tests (mocked connector) + integration tests (real MySQL, skip-gated) |
+
+---
+
+### Task 1: Add `mysql-connector-python` dependency
+
+**Files:**
+- Modify: `pyproject.toml:23-32` (dependencies list)
+
+- [ ] **Step 1: Add dependency to pyproject.toml**
+
+Add `mysql-connector-python>=8.0` to the dependencies list:
+
+```python
+dependencies = [
+    "duckdb>=1.0",
+    "pyarrow>=15.0",
+    "pyyaml>=6.0",
+    "typer>=0.9",
+    "pyodbc>=5.0",
+    "psycopg2-binary>=2.9",
+    "python-dotenv>=1.0",
+    "pytz",  # not imported directly, but DuckDB needs it for timestamp→Python conversion
+    "mysql-connector-python>=8.0",
+]
+```
+
+- [ ] **Step 2: Install**
+
+Run: `uv sync`
+
+- [ ] **Step 3: Verify import works**
+
+Run: `uv run python -c "import mysql.connector; print(mysql.connector.__version__)"`
+Expected: prints a version number (e.g., `9.x.x`)
+
+- [ ] **Step 4: Verify existing tests still pass**
+
+Run: `uv run pytest -q`
+Expected: 582 passed, 16 skipped
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "feat: add mysql-connector-python dependency for MySQL source (#25)"
+```
+
+---
+
+### Task 2: Implement `MySQLSource` core — `from_yaml`, `check`, `validate_source_table`
+
+**Files:**
+- Create: `src/feather_etl/sources/mysql.py`
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing tests for `from_yaml`**
+
+Create `tests/test_mysql.py`:
+
+```python
+"""Tests for MySQL source.
+
+Real-database tests are marked with a skip decorator and are skipped when
+the local MySQL instance is not reachable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.from_yaml — unit tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLFromYaml:
+    def test_minimal_entry_builds_connect_kwargs(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "db.example.com",
+            "user": "u",
+            "password": "p",
+            "database": "warehouse",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.name == "wh"
+        assert src.host == "db.example.com"
+        assert src.port == 3306
+        assert src.database == "warehouse"
+        assert src._connect_kwargs["host"] == "db.example.com"
+        assert src._connect_kwargs["port"] == 3306
+        assert src._connect_kwargs["database"] == "warehouse"
+        assert src._connect_kwargs["user"] == "u"
+        assert src._connect_kwargs["password"] == "p"
+
+    def test_explicit_port(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "h",
+            "port": 3307,
+            "user": "u",
+            "password": "p",
+            "database": "X",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.port == 3307
+        assert src._connect_kwargs["port"] == 3307
+
+    def test_explicit_connection_string(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "connection_string": "host=raw;database=verbatim",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.connection_string == "host=raw;database=verbatim"
+
+    def test_databases_list_and_xor_rules(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        ok = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "h",
+            "user": "u",
+            "password": "p",
+            "databases": ["A", "B"],
+        }
+        src = MySQLSource.from_yaml(ok, Path("."))
+        assert src.databases == ["A", "B"]
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            MySQLSource.from_yaml({**ok, "database": "C"}, Path("."))
+
+        with pytest.raises(ValueError, match="non-empty"):
+            MySQLSource.from_yaml({**ok, "databases": []}, Path("."))
+
+    def test_missing_host_and_connection_string_raises(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        with pytest.raises(ValueError, match="requires either"):
+            MySQLSource.from_yaml({"name": "x", "type": "mysql"}, Path("."))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_mysql.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'feather_etl.sources.mysql'`
+
+- [ ] **Step 3: Write the failing tests for `check` and `validate_source_table`**
+
+Append to `tests/test_mysql.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# MySQLSource — unit tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLSourceUnit:
+    def test_source_type_is_mysql(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        assert MySQLSource.type == "mysql"
+
+    def test_watermark_passthrough(self):
+        """MySQLSource uses the default _format_watermark (ISO unchanged)."""
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        assert src._format_watermark("2026-01-01T10:00:00") == "2026-01-01T10:00:00"
+
+    def test_build_where_filter_only(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(filter="active = 1")
+        assert result == " WHERE (active = 1)"
+
+    def test_build_where_watermark_only(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(
+            watermark_column="modified_at", watermark_value="2026-01-01"
+        )
+        assert result == " WHERE modified_at > '2026-01-01'"
+
+    def test_build_where_both(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(
+            filter="active = 1",
+            watermark_column="modified_at",
+            watermark_value="2026-01-01",
+        )
+        assert result == " WHERE (active = 1) AND modified_at > '2026-01-01'"
+
+
+class TestMySQLValidateSourceTable:
+    def test_plain_table_ok(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy", name="x")
+        assert src.validate_source_table("orders") == []
+
+    def test_qualified_table_ok(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy", name="x")
+        assert src.validate_source_table("mydb.orders") == []
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.check() — unit tests (mocked connector)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLCheckLastError:
+    def test_check_failure_populates_last_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        def boom(**kwargs):
+            raise mysql_mod.mysql.connector.Error("Access denied for user 'root'")
+
+        monkeypatch.setattr(mysql_mod.mysql.connector, "connect", boom)
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "nope"}
+        assert src.check() is False
+        assert src._last_error is not None
+        assert "Access denied" in src._last_error
+
+    def test_check_success_clears_last_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "localhost"}
+        src._last_error = "stale error from a prior call"
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            mysql_mod.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        assert src.check() is True
+        assert src._last_error is None
+```
+
+- [ ] **Step 4: Write minimal `MySQLSource` implementation**
+
+Create `src/feather_etl/sources/mysql.py`:
+
+```python
+"""MySQL source — reads from MySQL via mysql-connector-python."""
+
+from __future__ import annotations
+
+import decimal
+from pathlib import Path
+from typing import ClassVar
+
+import mysql.connector
+import pyarrow as pa
+
+from feather_etl.sources import ChangeResult, StreamSchema
+from feather_etl.sources.database_source import DatabaseSource
+
+# mysql.connector FieldType constants → PyArrow type
+_MYSQL_FIELD_TYPE_MAP: dict[int, pa.DataType] = {
+    0: pa.float64(),  # DECIMAL
+    1: pa.int8(),  # TINY
+    2: pa.int16(),  # SHORT
+    3: pa.int64(),  # LONG
+    4: pa.float32(),  # FLOAT
+    5: pa.float64(),  # DOUBLE
+    7: pa.timestamp("us"),  # TIMESTAMP
+    8: pa.int64(),  # LONGLONG
+    9: pa.int64(),  # INT24
+    10: pa.date32(),  # DATE
+    11: pa.time64("us"),  # TIME
+    12: pa.timestamp("us"),  # DATETIME
+    13: pa.int16(),  # YEAR
+    15: pa.string(),  # VARCHAR
+    16: pa.bool_(),  # BIT
+    246: pa.float64(),  # NEWDECIMAL
+    249: pa.binary(),  # TINY_BLOB
+    250: pa.binary(),  # MEDIUM_BLOB
+    251: pa.binary(),  # LONG_BLOB
+    252: pa.binary(),  # BLOB
+    253: pa.string(),  # VAR_STRING
+    254: pa.string(),  # STRING
+}
+
+# INFORMATION_SCHEMA DATA_TYPE string → PyArrow type
+_MYSQL_INFO_SCHEMA_TYPE_MAP: dict[str, pa.DataType] = {
+    "int": pa.int64(),
+    "bigint": pa.int64(),
+    "smallint": pa.int16(),
+    "tinyint": pa.int8(),
+    "mediumint": pa.int64(),
+    "float": pa.float32(),
+    "double": pa.float64(),
+    "decimal": pa.float64(),
+    "numeric": pa.float64(),
+    "bit": pa.bool_(),
+    "boolean": pa.bool_(),
+    "char": pa.string(),
+    "varchar": pa.string(),
+    "text": pa.string(),
+    "tinytext": pa.string(),
+    "mediumtext": pa.string(),
+    "longtext": pa.string(),
+    "enum": pa.string(),
+    "set": pa.string(),
+    "date": pa.date32(),
+    "time": pa.time64("us"),
+    "datetime": pa.timestamp("us"),
+    "timestamp": pa.timestamp("us"),
+    "year": pa.int16(),
+    "binary": pa.binary(),
+    "varbinary": pa.binary(),
+    "blob": pa.binary(),
+    "tinyblob": pa.binary(),
+    "mediumblob": pa.binary(),
+    "longblob": pa.binary(),
+    "json": pa.string(),
+}
+
+
+def _mysql_field_type_to_arrow(type_code: int) -> pa.DataType:
+    """Map a mysql.connector FieldType code to a PyArrow type."""
+    return _MYSQL_FIELD_TYPE_MAP.get(type_code, pa.string())
+
+
+class MySQLSource(DatabaseSource):
+    """Source that reads tables from MySQL via mysql-connector-python."""
+
+    type: ClassVar[str] = "mysql"
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        name: str = "",
+        host: str | None = None,
+        port: int | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
+        databases: list[str] | None = None,
+        batch_size: int = 120_000,
+    ) -> None:
+        super().__init__(connection_string)
+        self.name = name
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.database = database
+        self.databases = databases
+        self.batch_size = batch_size
+        self._last_error: str | None = None
+        self._connect_kwargs: dict = {}
+
+    def _connect(self):
+        """Return a MySQL connection using stored kwargs."""
+        return mysql.connector.connect(**self._connect_kwargs)
+
+    @classmethod
+    def from_yaml(cls, entry: dict, config_dir: Path) -> "MySQLSource":
+        name = entry.get("name", "")
+        explicit_conn = entry.get("connection_string")
+        host = entry.get("host")
+        port = entry.get("port", 3306)
+        user = entry.get("user")
+        password = entry.get("password")
+        database = entry.get("database")
+        databases = entry.get("databases")
+
+        if database is not None and databases is not None:
+            raise ValueError("database and databases are mutually exclusive; use one.")
+        if databases is not None and not databases:
+            raise ValueError("databases list must be non-empty.")
+
+        if explicit_conn:
+            conn_str = explicit_conn
+            connect_kwargs: dict = {}
+        elif host:
+            connect_kwargs = {"host": host, "port": port}
+            if database:
+                connect_kwargs["database"] = database
+            if user:
+                connect_kwargs["user"] = user
+            if password:
+                connect_kwargs["password"] = password
+            conn_str = (
+                f"host={host};port={port};database={database or ''}"
+                f";user={user or ''}"
+            )
+        else:
+            raise ValueError(
+                "mysql source requires either 'connection_string' or 'host'."
+            )
+
+        source = cls(
+            connection_string=conn_str,
+            name=name,
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            databases=databases,
+        )
+        source._connect_kwargs = connect_kwargs
+        source._explicit_name = bool(entry.get("name"))
+        return source
+
+    def validate_source_table(self, source_table: str) -> list[str]:
+        return []
+
+    def check(self) -> bool:
+        self._last_error = None
+        try:
+            conn = self._connect()
+            conn.close()
+            return True
+        except mysql.connector.Error as e:
+            self._last_error = str(e)
+            return False
+
+    def discover(self) -> list[StreamSchema]:
+        raise NotImplementedError("discover not yet implemented")
+
+    def get_schema(self, table: str) -> list[tuple[str, str]]:
+        raise NotImplementedError("get_schema not yet implemented")
+
+    def extract(
+        self,
+        table: str,
+        columns: list[str] | None = None,
+        filter: str | None = None,
+        watermark_column: str | None = None,
+        watermark_value: str | None = None,
+    ) -> pa.Table:
+        raise NotImplementedError("extract not yet implemented")
+
+    def detect_changes(
+        self, table: str, last_state: dict[str, object] | None = None
+    ) -> ChangeResult:
+        raise NotImplementedError("detect_changes not yet implemented")
+
+    def list_databases(self) -> list[str]:
+        raise NotImplementedError("list_databases not yet implemented")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_mysql.py -v`
+Expected: all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: add MySQLSource core — from_yaml, check, validate (#25)"
+```
+
+---
+
+### Task 3: Implement `discover`
+
+**Files:**
+- Modify: `src/feather_etl/sources/mysql.py` (replace `discover` stub)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/test_mysql.py`:
+
+```python
+MYSQL_CONN_KWARGS = {"host": "localhost", "user": "root", "database": "feather_test"}
+
+
+def _mysql_available() -> bool:
+    try:
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_CONN_KWARGS)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+mysql_db = pytest.mark.skipif(not _mysql_available(), reason="MySQL not available")
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource — integration tests (real MySQL required)
+# ---------------------------------------------------------------------------
+
+
+@mysql_db
+class TestMySQLDiscoverIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_discover_returns_erp_tables(self, source):
+        schemas = source.discover()
+        names = {s.name for s in schemas}
+        assert "erp_customers" in names
+        assert "erp_products" in names
+        assert "erp_sales" in names
+
+    def test_discover_schema_fields(self, source):
+        schemas = source.discover()
+        sales = next(s for s in schemas if s.name == "erp_sales")
+        assert sales.supports_incremental is True
+        assert sales.primary_key is None
+        col_names = [c[0] for c in sales.columns]
+        assert "id" in col_names
+        assert "amount" in col_names
+
+    def test_discover_column_types(self, source):
+        schemas = source.discover()
+        sales = next(s for s in schemas if s.name == "erp_sales")
+        col_types = {c[0]: c[1] for c in sales.columns}
+        assert col_types["id"] == "int"
+        assert col_types["product"] == "varchar"
+        assert col_types["amount"] == "decimal"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLDiscoverIntegration -v`
+Expected: FAIL — `NotImplementedError: discover not yet implemented`
+
+- [ ] **Step 3: Implement `discover`**
+
+Replace the `discover` stub in `src/feather_etl/sources/mysql.py`:
+
+```python
+    def discover(self) -> list[StreamSchema]:
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT TABLE_NAME "
+                "FROM INFORMATION_SCHEMA.TABLES "
+                "WHERE TABLE_SCHEMA = %s "
+                "AND TABLE_TYPE = 'BASE TABLE' "
+                "ORDER BY TABLE_NAME",
+                (self.database,),
+            )
+            tables = cursor.fetchall()
+
+            schemas: list[StreamSchema] = []
+            for (table_name,) in tables:
+                cursor.execute(
+                    "SELECT COLUMN_NAME, DATA_TYPE "
+                    "FROM INFORMATION_SCHEMA.COLUMNS "
+                    "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                    "ORDER BY ORDINAL_POSITION",
+                    (self.database, table_name),
+                )
+                cols = cursor.fetchall()
+                schemas.append(
+                    StreamSchema(
+                        name=table_name,
+                        columns=[(c[0], c[1]) for c in cols],
+                        primary_key=None,
+                        supports_incremental=True,
+                    )
+                )
+
+            cursor.close()
+            return schemas
+        finally:
+            conn.close()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLDiscoverIntegration -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: implement MySQLSource.discover() (#25)"
+```
+
+---
+
+### Task 4: Implement `get_schema`
+
+**Files:**
+- Modify: `src/feather_etl/sources/mysql.py` (replace `get_schema` stub)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Append to `tests/test_mysql.py`:
+
+```python
+@mysql_db
+class TestMySQLGetSchemaIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_get_schema_returns_columns(self, source):
+        cols = source.get_schema("erp_sales")
+        col_names = [c[0] for c in cols]
+        assert "id" in col_names
+        assert "customer_id" in col_names
+        assert "product" in col_names
+        assert "amount" in col_names
+        assert "modified_at" in col_names
+
+    def test_get_schema_returns_types(self, source):
+        cols = source.get_schema("erp_sales")
+        col_types = {c[0]: c[1] for c in cols}
+        assert col_types["id"] == "int"
+        assert col_types["amount"] == "decimal"
+        assert col_types["modified_at"] == "timestamp"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLGetSchemaIntegration -v`
+Expected: FAIL — `NotImplementedError: get_schema not yet implemented`
+
+- [ ] **Step 3: Implement `get_schema`**
+
+Replace the `get_schema` stub in `src/feather_etl/sources/mysql.py`:
+
+```python
+    def get_schema(self, table: str) -> list[tuple[str, str]]:
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COLUMN_NAME, DATA_TYPE "
+                "FROM INFORMATION_SCHEMA.COLUMNS "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                "ORDER BY ORDINAL_POSITION",
+                (self.database, table),
+            )
+            cols = cursor.fetchall()
+            cursor.close()
+            return [(c[0], c[1]) for c in cols]
+        finally:
+            conn.close()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLGetSchemaIntegration -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: implement MySQLSource.get_schema() (#25)"
+```
+
+---
+
+### Task 5: Implement `extract` with type mapping
+
+**Files:**
+- Modify: `src/feather_etl/sources/mysql.py` (replace `extract` stub)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/test_mysql.py`:
+
+```python
+@mysql_db
+class TestMySQLExtractIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_extract_full(self, source):
+        import pyarrow as pa
+
+        table = source.extract("erp_sales")
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 10
+        assert "id" in table.column_names
+        assert "amount" in table.column_names
+
+    def test_extract_with_columns(self, source):
+        table = source.extract("erp_customers", columns=["id", "name"])
+        assert table.column_names == ["id", "name"]
+        assert table.num_rows == 4
+
+    def test_extract_with_filter(self, source):
+        table = source.extract("erp_sales", filter="amount > 150")
+        assert table.num_rows > 0
+        amounts = table.column("amount").to_pylist()
+        assert all(a > 150 for a in amounts)
+
+    def test_extract_incremental_with_watermark(self, source):
+        import pyarrow as pa
+
+        table = source.extract(
+            "erp_sales",
+            watermark_column="modified_at",
+            watermark_value="2026-01-03",
+        )
+        assert isinstance(table, pa.Table)
+        assert table.num_rows > 0
+
+    def test_extract_empty_result(self, source):
+        import pyarrow as pa
+
+        table = source.extract("erp_sales", filter="id = -999")
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLExtractIntegration -v`
+Expected: FAIL — `NotImplementedError: extract not yet implemented`
+
+- [ ] **Step 3: Implement `extract`**
+
+Replace the `extract` stub in `src/feather_etl/sources/mysql.py`:
+
+```python
+    def extract(
+        self,
+        table: str,
+        columns: list[str] | None = None,
+        filter: str | None = None,
+        watermark_column: str | None = None,
+        watermark_value: str | None = None,
+    ) -> pa.Table:
+        conn = self._connect()
+        cursor = conn.cursor()
+
+        col_clause = ", ".join(columns) if columns else "*"
+        where = self._build_where_clause(filter, watermark_column, watermark_value)
+        query = f"SELECT {col_clause} FROM {table}{where}"
+
+        cursor.execute(query)
+
+        if cursor.description is None:
+            cursor.close()
+            conn.close()
+            return pa.table({})
+
+        col_names = [desc[0] for desc in cursor.description]
+        col_types = [_mysql_field_type_to_arrow(desc[1]) for desc in cursor.description]
+        arrow_schema = pa.schema(
+            [pa.field(name, typ) for name, typ in zip(col_names, col_types)]
+        )
+
+        batches: list[pa.RecordBatch] = []
+        while True:
+            rows = cursor.fetchmany(self.batch_size)
+            if not rows:
+                break
+            col_data: dict[str, list] = {name: [] for name in col_names}
+            for row in rows:
+                for i, name in enumerate(col_names):
+                    val = row[i]
+                    if isinstance(val, decimal.Decimal):
+                        val = float(val)
+                    col_data[name].append(val)
+            batch = pa.RecordBatch.from_pydict(col_data, schema=arrow_schema)
+            batches.append(batch)
+
+        cursor.close()
+        conn.close()
+
+        if not batches:
+            return pa.table(
+                {
+                    name: pa.array([], type=typ)
+                    for name, typ in zip(col_names, col_types)
+                }
+            )
+
+        return pa.Table.from_batches(batches, schema=arrow_schema)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLExtractIntegration -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: implement MySQLSource.extract() with type mapping (#25)"
+```
+
+---
+
+### Task 6: Implement `detect_changes`
+
+**Files:**
+- Modify: `src/feather_etl/sources/mysql.py` (replace `detect_changes` stub)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Append to `tests/test_mysql.py`:
+
+```python
+@mysql_db
+class TestMySQLDetectChangesIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_detect_changes_first_run(self, source):
+        result = source.detect_changes("erp_sales", last_state=None)
+        assert result.changed is True
+        assert result.reason == "first_run"
+        assert "checksum" in result.metadata
+
+    def test_detect_changes_unchanged(self, source):
+        first = source.detect_changes("erp_sales", last_state=None)
+        last_state = {
+            "last_checksum": first.metadata.get("checksum"),
+        }
+        second = source.detect_changes("erp_sales", last_state=last_state)
+        assert second.changed is False
+        assert second.reason == "unchanged"
+
+    def test_detect_changes_incremental_always_changed(self, source):
+        last_state = {"strategy": "incremental"}
+        result = source.detect_changes("erp_sales", last_state=last_state)
+        assert result.changed is True
+        assert result.reason == "incremental"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLDetectChangesIntegration -v`
+Expected: FAIL — `NotImplementedError: detect_changes not yet implemented`
+
+- [ ] **Step 3: Implement `detect_changes`**
+
+Replace the `detect_changes` stub in `src/feather_etl/sources/mysql.py`:
+
+```python
+    def detect_changes(
+        self, table: str, last_state: dict[str, object] | None = None
+    ) -> ChangeResult:
+        if last_state is not None and last_state.get("strategy") == "incremental":
+            return ChangeResult(changed=True, reason="incremental")
+
+        try:
+            conn = self._connect()
+            cursor = conn.cursor()
+            # CHECKSUM TABLE returns (table_name, checksum_value)
+            qualified = f"{self.database}.{table}" if self.database else table
+            cursor.execute(f"CHECKSUM TABLE {qualified}")
+            row = cursor.fetchone()
+            cursor.close()
+            conn.close()
+        except mysql.connector.Error:
+            return ChangeResult(changed=True, reason="checksum_error")
+
+        if row is None:
+            return ChangeResult(changed=True, reason="first_run")
+
+        current_checksum = row[1]
+
+        if last_state is None or last_state.get("last_checksum") is None:
+            return ChangeResult(
+                changed=True,
+                reason="first_run",
+                metadata={"checksum": current_checksum},
+            )
+
+        if current_checksum == last_state.get("last_checksum"):
+            return ChangeResult(changed=False, reason="unchanged")
+
+        return ChangeResult(
+            changed=True,
+            reason="checksum_changed",
+            metadata={"checksum": current_checksum},
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLDetectChangesIntegration -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: implement MySQLSource.detect_changes() (#25)"
+```
+
+---
+
+### Task 7: Implement `list_databases`
+
+**Files:**
+- Modify: `src/feather_etl/sources/mysql.py` (replace `list_databases` stub)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing unit test**
+
+Append to `tests/test_mysql.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# MySQLSource.list_databases — unit tests (mocked connector)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLListDatabases:
+    def test_query_filters_system_dbs(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        captured_sql: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                captured_sql.append(sql)
+
+            def fetchall(self):
+                return [("warehouse",), ("analytics",)]
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            mysql_mod.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "localhost"}
+        result = src.list_databases()
+
+        assert result == ["warehouse", "analytics"]
+        sql = captured_sql[0]
+        assert "SCHEMA_NAME" in sql
+        assert "information_schema" in sql
+        assert "mysql" in sql
+        assert "performance_schema" in sql
+        assert "sys" in sql
+
+    def test_propagates_connector_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        def raise_(**k):
+            raise mysql_mod.mysql.connector.Error("connection refused")
+
+        monkeypatch.setattr(mysql_mod.mysql.connector, "connect", raise_)
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "nope"}
+        with pytest.raises(mysql_mod.mysql.connector.Error):
+            src.list_databases()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLListDatabases -v`
+Expected: FAIL — `NotImplementedError: list_databases not yet implemented`
+
+- [ ] **Step 3: Implement `list_databases`**
+
+Replace the `list_databases` stub in `src/feather_etl/sources/mysql.py`:
+
+```python
+    def list_databases(self) -> list[str]:
+        """Return user databases on the server (excludes system databases).
+
+        Raises mysql.connector.Error on connection/query failure (caller handles).
+        """
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
+                "WHERE SCHEMA_NAME NOT IN "
+                "('information_schema', 'mysql', 'performance_schema', 'sys') "
+                "ORDER BY SCHEMA_NAME"
+            )
+            rows = cursor.fetchall()
+            cursor.close()
+            return [r[0] for r in rows]
+        finally:
+            conn.close()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLListDatabases -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/sources/mysql.py tests/test_mysql.py
+git commit -m "feat: implement MySQLSource.list_databases() (#25)"
+```
+
+---
+
+### Task 8: Register in registry
+
+**Files:**
+- Modify: `src/feather_etl/sources/registry.py:17-25` (add to `SOURCE_CLASSES`)
+- Test: `tests/test_mysql.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mysql.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Registry — unit test
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLRegistry:
+    def test_source_in_registry(self):
+        from feather_etl.sources.mysql import MySQLSource
+        from feather_etl.sources.registry import get_source_class
+
+        assert get_source_class("mysql") is MySQLSource
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLRegistry -v`
+Expected: FAIL — `ValueError: Source type 'mysql' is not implemented`
+
+- [ ] **Step 3: Add registry entry**
+
+Add to `SOURCE_CLASSES` dict in `src/feather_etl/sources/registry.py`:
+
+```python
+SOURCE_CLASSES: dict[str, str] = {
+    "duckdb": "feather_etl.sources.duckdb_file.DuckDBFileSource",
+    "csv": "feather_etl.sources.csv.CsvSource",
+    "sqlite": "feather_etl.sources.sqlite.SqliteSource",
+    "sqlserver": "feather_etl.sources.sqlserver.SqlServerSource",
+    "postgres": "feather_etl.sources.postgres.PostgresSource",
+    "excel": "feather_etl.sources.excel.ExcelSource",
+    "json": "feather_etl.sources.json_source.JsonSource",
+    "mysql": "feather_etl.sources.mysql.MySQLSource",
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_mysql.py::TestMySQLRegistry -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `uv run pytest -q`
+Expected: 582+ passed, skipped count may increase (MySQL integration tests counted)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/feather_etl/sources/registry.py tests/test_mysql.py
+git commit -m "feat: register mysql source type in registry (#25)"
+```

--- a/docs/plans/2026-04-18-mysql-source.md
+++ b/docs/plans/2026-04-18-mysql-source.md
@@ -1,0 +1,131 @@
+# MySQL Source — Design Spec
+
+**Issue:** #25 — Support Extraction from MySQL DB
+**Date:** 2026-04-18
+**Status:** APPROVED
+
+## Scope & Boundaries
+
+**In:** A new `mysql` source type that extracts tables from MySQL databases into DuckDB, following the same pattern as Postgres/SQL Server. Includes YAML config parsing (`from_yaml`), connectivity check, table discovery, schema introspection, extraction with filtering/watermarks, change detection, multi-database listing, and registry integration. Unit tests + integration tests (gated behind `pytest.mark.mysql`).
+
+**Out:** No MySQL-specific features beyond what Postgres already supports — no stored procedure extraction, no replication-based CDC, no SSL configuration beyond what `connection_string` allows. View discovery is tracked separately (#26).
+
+## User-Facing Contract
+
+New YAML config shape:
+
+```yaml
+sources:
+  - name: my_erp
+    type: mysql
+    host: localhost
+    port: 3306          # optional, default 3306
+    user: root
+    password: secret
+    database: erp_db
+```
+
+Alternative: `connection_string:` for raw connection strings. `databases:` list for multi-DB discovery (XOR with `database:`). Table names are unqualified (`erp_sales`), database set at source level. All patterns identical to Postgres/SQL Server — no new concepts for users.
+
+## Integration Surface
+
+| File | Change | Risk |
+|---|---|---|
+| `src/feather_etl/sources/mysql.py` | **New file** — `MySQLSource` class | None (new code) |
+| `src/feather_etl/sources/registry.py` | One line added to `SOURCE_CLASSES` dict | Minimal |
+| `pyproject.toml` | One line added to `dependencies` | Minimal |
+| `tests/test_mysql.py` | **New file** — unit + integration tests | None (new code) |
+
+Only 2 existing files get single-line edits. Low blast radius.
+
+## Task Breakdown
+
+### Task 1: Add `mysql-connector-python` dependency
+
+- **What:** Add `mysql-connector-python>=8.0` to `pyproject.toml` dependencies, run `uv sync`.
+- **Why/Risk:** Required for MySQL connectivity. Risk: version conflicts — mitigated by `>=8.0` floor (widely compatible).
+- **TDD test:** `import mysql.connector` succeeds.
+- **Code:** One line in `pyproject.toml`.
+
+### Task 2: Implement `MySQLSource` core — `from_yaml`, `check`, `validate_source_table`
+
+- **What:** Create `mysql.py` with config parsing, connectivity check, and source_table validation.
+- **Why/Risk:** Foundation for all other methods. Risk: `mysql-connector-python` uses keyword args (not DSN strings like psycopg2) — handled via `_connect_kwargs` dict and `_connect()` helper.
+- **TDD test:** `from_yaml` builds correct connection params from host/port/user/password/database; enforces database/databases XOR; `check()` returns True/False with monkeypatched connector.
+- **Code:** `MySQLSource` class extending `DatabaseSource`, `from_yaml` classmethod, `check()` method, `_connect()` helper.
+
+### Task 3: Implement `discover`
+
+- **What:** Query `INFORMATION_SCHEMA.TABLES` to list base tables in the connected database.
+- **Why/Risk:** Enables `feather discover`. Risk: MySQL returns all databases in INFORMATION_SCHEMA — must filter with `TABLE_SCHEMA = database`.
+- **TDD test:** Integration: `discover()` returns the 3 `erp_*` tables from `feather_test` with correct column info.
+- **Code:** `discover()` method querying `INFORMATION_SCHEMA.TABLES` + `INFORMATION_SCHEMA.COLUMNS`.
+
+### Task 4: Implement `get_schema`
+
+- **What:** Query `INFORMATION_SCHEMA.COLUMNS` for a given table's column names and types.
+- **Why/Risk:** Enables schema viewer. Risk: minimal — standard INFORMATION_SCHEMA query.
+- **TDD test:** Integration: `get_schema("erp_sales")` returns expected columns (`id`, `customer_id`, `product`, `amount`, `modified_at`).
+- **Code:** `get_schema()` method.
+
+### Task 5: Implement `extract` with type mapping
+
+- **What:** SELECT → chunked fetch → PyArrow Table, with column/filter/watermark support.
+- **Why/Risk:** The core ETL operation. Risk: MySQL `cursor.description` type codes differ from Postgres — need `FieldType` constant → PyArrow mapping. `Decimal` values need float coercion.
+- **TDD test:** Integration: `extract("erp_sales")` returns 10 rows with correct columns; `extract("erp_sales", filter="amount > 150")` returns filtered subset; watermark extract returns only newer rows.
+- **Code:** `extract()` method + `_MYSQL_FIELD_TYPE_MAP` dict + `_MYSQL_INFO_SCHEMA_TYPE_MAP` dict.
+
+### Task 6: Implement `detect_changes`
+
+- **What:** Change detection to skip unchanged tables.
+- **Why/Risk:** Enables skip-unchanged optimization. Risk: MySQL lacks Postgres's `row_to_json` — use `CHECKSUM TABLE` (MySQL built-in) instead.
+- **TDD test:** Integration: first_run → changed; same state fed back → unchanged; incremental strategy → always changed.
+- **Code:** `detect_changes()` method using `CHECKSUM TABLE`.
+
+### Task 7: Implement `list_databases`
+
+- **What:** List user databases on the server, excluding system DBs.
+- **Why/Risk:** Enables multi-database discovery via `databases:` YAML key. Risk: minimal — `SHOW DATABASES` is standard MySQL.
+- **TDD test:** Unit (mocked): returns user DBs, excludes `information_schema`, `mysql`, `performance_schema`, `sys`. Propagates connector errors.
+- **Code:** `list_databases()` method using `SHOW DATABASES`.
+
+### Task 8: Register in registry
+
+- **What:** Add `"mysql"` entry to `SOURCE_CLASSES` in `registry.py`.
+- **Why/Risk:** Makes `type: mysql` work in YAML. Risk: none — one-line addition, lazy import.
+- **TDD test:** `get_source_class("mysql") is MySQLSource`.
+- **Code:** One dict entry in `registry.py`.
+
+## Dependency Chain
+
+```
+Task 1 (dependency) → Task 2 (core) → Task 3 (discover)
+                                     → Task 4 (get_schema)
+                                     → Task 5 (extract)
+                                     → Task 6 (detect_changes)
+                                     → Task 7 (list_databases)
+                      Task 8 (registry) — anytime after Task 2
+```
+
+Tasks 3–7 are independent of each other, all depend on Task 2.
+
+## Done Signal
+
+```bash
+uv run pytest tests/test_mysql.py -v   # all unit + integration tests pass
+uv run pytest -q                        # full suite still green (582+ passed)
+```
+
+## Key MySQL vs Postgres Differences
+
+| Concern | Postgres | MySQL |
+|---|---|---|
+| Default port | 5432 | 3306 |
+| Default schema | `public` | n/a (database = schema) |
+| System schemas to exclude in `discover()` | `pg_catalog`, `information_schema` | n/a (filter by `TABLE_SCHEMA = database`) |
+| Change detection | `md5(string_agg(row_to_json(...)))` | `CHECKSUM TABLE` |
+| Watermark formatting | ISO passthrough | ISO passthrough |
+| Connection API | DSN string | Keyword args dict |
+| `list_databases()` | `pg_database` catalog | `SHOW DATABASES` |
+| Parameter placeholder | `%s` | `%s` (same) |
+| Driver | psycopg2 | mysql-connector-python |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "psycopg2-binary>=2.9",
     "python-dotenv>=1.0",
     "pytz",  # not imported directly, but DuckDB needs it for timestamp→Python conversion
+    "mysql-connector-python>=8.0",
 ]
 
 [project.urls]

--- a/src/feather_etl/commands/discover.py
+++ b/src/feather_etl/commands/discover.py
@@ -45,12 +45,13 @@ def _expand_db_sources(sources: list) -> list:
         produce one child per result.
       - File sources → keep as-is.
     """
+    from feather_etl.sources.mysql import MySQLSource
     from feather_etl.sources.postgres import PostgresSource
     from feather_etl.sources.sqlserver import SqlServerSource
 
     expanded: list = []
     for src in sources:
-        is_db = isinstance(src, (SqlServerSource, PostgresSource))
+        is_db = isinstance(src, (SqlServerSource, PostgresSource, MySQLSource))
         if not is_db:
             expanded.append(src)
             continue

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -179,7 +179,43 @@ class MySQLSource(DatabaseSource):
             return False
 
     def discover(self) -> list[StreamSchema]:
-        raise NotImplementedError("discover not yet implemented")
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT TABLE_NAME "
+                "FROM INFORMATION_SCHEMA.TABLES "
+                "WHERE TABLE_SCHEMA = %s "
+                "AND TABLE_TYPE = 'BASE TABLE' "
+                "ORDER BY TABLE_NAME",
+                (self.database,),
+            )
+            tables = cursor.fetchall()
+
+            schemas: list[StreamSchema] = []
+            for (table_name,) in tables:
+                cursor.execute(
+                    "SELECT COLUMN_NAME, DATA_TYPE "
+                    "FROM INFORMATION_SCHEMA.COLUMNS "
+                    "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                    "ORDER BY ORDINAL_POSITION",
+                    (self.database, table_name),
+                )
+                cols = cursor.fetchall()
+                schemas.append(
+                    StreamSchema(
+                        name=table_name,
+                        columns=[(c[0], c[1]) for c in cols],
+                        primary_key=None,
+                        supports_incremental=True,
+                    )
+                )
+
+            cursor.close()
+            return schemas
+        finally:
+            conn.close()
 
     def get_schema(self, table: str) -> list[tuple[str, str]]:
         raise NotImplementedError("get_schema not yet implemented")

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import decimal
 from pathlib import Path
 from typing import ClassVar
 
@@ -108,10 +107,13 @@ class MySQLSource(DatabaseSource):
         self.batch_size = batch_size
         self._last_error: str | None = None
         self._connect_kwargs: dict = {}
+        self._explicit_name: bool = False
 
     def _connect(self):
-        """Return a MySQL connection using stored kwargs."""
-        return mysql.connector.connect(**self._connect_kwargs)
+        """Return a MySQL connection using stored kwargs or connection_string."""
+        if self._connect_kwargs:
+            return mysql.connector.connect(**self._connect_kwargs)
+        return mysql.connector.connect(self.connection_string)
 
     @classmethod
     def from_yaml(cls, entry: dict, config_dir: Path) -> "MySQLSource":

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -144,8 +144,7 @@ class MySQLSource(DatabaseSource):
             if password:
                 connect_kwargs["password"] = password
             conn_str = (
-                f"host={host};port={port};database={database or ''}"
-                f";user={user or ''}"
+                f"host={host};port={port};database={database or ''};user={user or ''}"
             )
         else:
             raise ValueError(

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -1,0 +1,201 @@
+"""MySQL source — reads from MySQL via mysql-connector-python."""
+
+from __future__ import annotations
+
+import decimal
+from pathlib import Path
+from typing import ClassVar
+
+import mysql.connector
+import pyarrow as pa
+
+from feather_etl.sources import ChangeResult, StreamSchema
+from feather_etl.sources.database_source import DatabaseSource
+
+# mysql.connector FieldType constants → PyArrow type
+_MYSQL_FIELD_TYPE_MAP: dict[int, pa.DataType] = {
+    0: pa.float64(),  # DECIMAL
+    1: pa.int8(),  # TINY
+    2: pa.int16(),  # SHORT
+    3: pa.int64(),  # LONG
+    4: pa.float32(),  # FLOAT
+    5: pa.float64(),  # DOUBLE
+    7: pa.timestamp("us"),  # TIMESTAMP
+    8: pa.int64(),  # LONGLONG
+    9: pa.int64(),  # INT24
+    10: pa.date32(),  # DATE
+    11: pa.time64("us"),  # TIME
+    12: pa.timestamp("us"),  # DATETIME
+    13: pa.int16(),  # YEAR
+    15: pa.string(),  # VARCHAR
+    16: pa.bool_(),  # BIT
+    246: pa.float64(),  # NEWDECIMAL
+    249: pa.binary(),  # TINY_BLOB
+    250: pa.binary(),  # MEDIUM_BLOB
+    251: pa.binary(),  # LONG_BLOB
+    252: pa.binary(),  # BLOB
+    253: pa.string(),  # VAR_STRING
+    254: pa.string(),  # STRING
+}
+
+# INFORMATION_SCHEMA DATA_TYPE string → PyArrow type
+_MYSQL_INFO_SCHEMA_TYPE_MAP: dict[str, pa.DataType] = {
+    "int": pa.int64(),
+    "bigint": pa.int64(),
+    "smallint": pa.int16(),
+    "tinyint": pa.int8(),
+    "mediumint": pa.int64(),
+    "float": pa.float32(),
+    "double": pa.float64(),
+    "decimal": pa.float64(),
+    "numeric": pa.float64(),
+    "bit": pa.bool_(),
+    "boolean": pa.bool_(),
+    "char": pa.string(),
+    "varchar": pa.string(),
+    "text": pa.string(),
+    "tinytext": pa.string(),
+    "mediumtext": pa.string(),
+    "longtext": pa.string(),
+    "enum": pa.string(),
+    "set": pa.string(),
+    "date": pa.date32(),
+    "time": pa.time64("us"),
+    "datetime": pa.timestamp("us"),
+    "timestamp": pa.timestamp("us"),
+    "year": pa.int16(),
+    "binary": pa.binary(),
+    "varbinary": pa.binary(),
+    "blob": pa.binary(),
+    "tinyblob": pa.binary(),
+    "mediumblob": pa.binary(),
+    "longblob": pa.binary(),
+    "json": pa.string(),
+}
+
+
+def _mysql_field_type_to_arrow(type_code: int) -> pa.DataType:
+    """Map a mysql.connector FieldType code to a PyArrow type."""
+    return _MYSQL_FIELD_TYPE_MAP.get(type_code, pa.string())
+
+
+class MySQLSource(DatabaseSource):
+    """Source that reads tables from MySQL via mysql-connector-python."""
+
+    type: ClassVar[str] = "mysql"
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        name: str = "",
+        host: str | None = None,
+        port: int | None = None,
+        user: str | None = None,
+        password: str | None = None,
+        database: str | None = None,
+        databases: list[str] | None = None,
+        batch_size: int = 120_000,
+    ) -> None:
+        super().__init__(connection_string)
+        self.name = name
+        self.host = host
+        self.port = port
+        self.user = user
+        self.password = password
+        self.database = database
+        self.databases = databases
+        self.batch_size = batch_size
+        self._last_error: str | None = None
+        self._connect_kwargs: dict = {}
+
+    def _connect(self):
+        """Return a MySQL connection using stored kwargs."""
+        return mysql.connector.connect(**self._connect_kwargs)
+
+    @classmethod
+    def from_yaml(cls, entry: dict, config_dir: Path) -> "MySQLSource":
+        name = entry.get("name", "")
+        explicit_conn = entry.get("connection_string")
+        host = entry.get("host")
+        port = entry.get("port", 3306)
+        user = entry.get("user")
+        password = entry.get("password")
+        database = entry.get("database")
+        databases = entry.get("databases")
+
+        if database is not None and databases is not None:
+            raise ValueError("database and databases are mutually exclusive; use one.")
+        if databases is not None and not databases:
+            raise ValueError("databases list must be non-empty.")
+
+        if explicit_conn:
+            conn_str = explicit_conn
+            connect_kwargs: dict = {}
+        elif host:
+            connect_kwargs = {"host": host, "port": port}
+            if database:
+                connect_kwargs["database"] = database
+            if user:
+                connect_kwargs["user"] = user
+            if password:
+                connect_kwargs["password"] = password
+            conn_str = (
+                f"host={host};port={port};database={database or ''}"
+                f";user={user or ''}"
+            )
+        else:
+            raise ValueError(
+                "mysql source requires either 'connection_string' or 'host'."
+            )
+
+        source = cls(
+            connection_string=conn_str,
+            name=name,
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            databases=databases,
+        )
+        source._connect_kwargs = connect_kwargs
+        source._explicit_name = bool(entry.get("name"))
+        return source
+
+    def validate_source_table(self, source_table: str) -> list[str]:
+        return []
+
+    def check(self) -> bool:
+        self._last_error = None
+        try:
+            conn = self._connect()
+            conn.close()
+            return True
+        except mysql.connector.Error as e:
+            self._last_error = str(e)
+            return False
+
+    def discover(self) -> list[StreamSchema]:
+        raise NotImplementedError("discover not yet implemented")
+
+    def get_schema(self, table: str) -> list[tuple[str, str]]:
+        raise NotImplementedError("get_schema not yet implemented")
+
+    def extract(
+        self,
+        table: str,
+        columns: list[str] | None = None,
+        filter: str | None = None,
+        watermark_column: str | None = None,
+        watermark_value: str | None = None,
+    ) -> pa.Table:
+        raise NotImplementedError("extract not yet implemented")
+
+    def detect_changes(
+        self, table: str, last_state: dict[str, object] | None = None
+    ) -> ChangeResult:
+        raise NotImplementedError("detect_changes not yet implemented")
+
+    def list_databases(self) -> list[str]:
+        raise NotImplementedError("list_databases not yet implemented")

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -331,4 +331,21 @@ class MySQLSource(DatabaseSource):
         )
 
     def list_databases(self) -> list[str]:
-        raise NotImplementedError("list_databases not yet implemented")
+        """Return user databases on the server (excludes system databases).
+
+        Raises mysql.connector.Error on connection/query failure (caller handles).
+        """
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA "
+                "WHERE SCHEMA_NAME NOT IN "
+                "('information_schema', 'mysql', 'performance_schema', 'sys') "
+                "ORDER BY SCHEMA_NAME"
+            )
+            rows = cursor.fetchall()
+            cursor.close()
+            return [r[0] for r in rows]
+        finally:
+            conn.close()

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import decimal
 from pathlib import Path
 from typing import ClassVar
 
@@ -242,7 +243,53 @@ class MySQLSource(DatabaseSource):
         watermark_column: str | None = None,
         watermark_value: str | None = None,
     ) -> pa.Table:
-        raise NotImplementedError("extract not yet implemented")
+        conn = self._connect()
+        cursor = conn.cursor()
+
+        col_clause = ", ".join(columns) if columns else "*"
+        where = self._build_where_clause(filter, watermark_column, watermark_value)
+        query = f"SELECT {col_clause} FROM {table}{where}"
+
+        cursor.execute(query)
+
+        if cursor.description is None:
+            cursor.close()
+            conn.close()
+            return pa.table({})
+
+        col_names = [desc[0] for desc in cursor.description]
+        col_types = [_mysql_field_type_to_arrow(desc[1]) for desc in cursor.description]
+        arrow_schema = pa.schema(
+            [pa.field(name, typ) for name, typ in zip(col_names, col_types)]
+        )
+
+        batches: list[pa.RecordBatch] = []
+        while True:
+            rows = cursor.fetchmany(self.batch_size)
+            if not rows:
+                break
+            col_data: dict[str, list] = {name: [] for name in col_names}
+            for row in rows:
+                for i, name in enumerate(col_names):
+                    val = row[i]
+                    if isinstance(val, decimal.Decimal):
+                        val = float(val)
+                    col_data[name].append(val)
+            batch = pa.RecordBatch.from_pydict(col_data, schema=arrow_schema)
+            batches.append(batch)
+
+        cursor.close()
+        conn.close()
+
+        if not batches:
+            return pa.table(
+                {
+                    name: pa.array([], type=typ)
+                    for name, typ in zip(col_names, col_types)
+                }
+            )
+
+        return pa.Table.from_batches(batches, schema=arrow_schema)
 
     def detect_changes(
         self, table: str, last_state: dict[str, object] | None = None

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -294,7 +294,41 @@ class MySQLSource(DatabaseSource):
     def detect_changes(
         self, table: str, last_state: dict[str, object] | None = None
     ) -> ChangeResult:
-        raise NotImplementedError("detect_changes not yet implemented")
+        if last_state is not None and last_state.get("strategy") == "incremental":
+            return ChangeResult(changed=True, reason="incremental")
+
+        try:
+            conn = self._connect()
+            cursor = conn.cursor()
+            # CHECKSUM TABLE returns (table_name, checksum_value)
+            qualified = f"{self.database}.{table}" if self.database else table
+            cursor.execute(f"CHECKSUM TABLE {qualified}")
+            row = cursor.fetchone()
+            cursor.close()
+            conn.close()
+        except mysql.connector.Error:
+            return ChangeResult(changed=True, reason="checksum_error")
+
+        if row is None:
+            return ChangeResult(changed=True, reason="first_run")
+
+        current_checksum = row[1]
+
+        if last_state is None or last_state.get("last_checksum") is None:
+            return ChangeResult(
+                changed=True,
+                reason="first_run",
+                metadata={"checksum": current_checksum},
+            )
+
+        if current_checksum == last_state.get("last_checksum"):
+            return ChangeResult(changed=False, reason="unchanged")
+
+        return ChangeResult(
+            changed=True,
+            reason="checksum_changed",
+            metadata={"checksum": current_checksum},
+        )
 
     def list_databases(self) -> list[str]:
         raise NotImplementedError("list_databases not yet implemented")

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -114,7 +114,7 @@ class MySQLSource(DatabaseSource):
         """Return a MySQL connection using stored kwargs or connection_string."""
         if self._connect_kwargs:
             return mysql.connector.connect(**self._connect_kwargs)
-        return mysql.connector.connect(self.connection_string)
+        return mysql.connector.connect(connection_string=self.connection_string)
 
     @classmethod
     def from_yaml(cls, entry: dict, config_dir: Path) -> "MySQLSource":
@@ -180,6 +180,8 @@ class MySQLSource(DatabaseSource):
             return False
 
     def discover(self) -> list[StreamSchema]:
+        if not self.database:
+            raise ValueError("discover() requires database to be set.")
         conn = self._connect()
         try:
             cursor = conn.cursor()
@@ -244,52 +246,55 @@ class MySQLSource(DatabaseSource):
         watermark_value: str | None = None,
     ) -> pa.Table:
         conn = self._connect()
-        cursor = conn.cursor()
+        try:
+            cursor = conn.cursor()
 
-        col_clause = ", ".join(columns) if columns else "*"
-        where = self._build_where_clause(filter, watermark_column, watermark_value)
-        query = f"SELECT {col_clause} FROM {table}{where}"
+            col_clause = ", ".join(columns) if columns else "*"
+            where = self._build_where_clause(filter, watermark_column, watermark_value)
+            query = f"SELECT {col_clause} FROM {table}{where}"
 
-        cursor.execute(query)
+            cursor.execute(query)
 
-        if cursor.description is None:
-            cursor.close()
-            conn.close()
-            return pa.table({})
+            if cursor.description is None:
+                cursor.close()
+                return pa.table({})
 
-        col_names = [desc[0] for desc in cursor.description]
-        col_types = [_mysql_field_type_to_arrow(desc[1]) for desc in cursor.description]
-        arrow_schema = pa.schema(
-            [pa.field(name, typ) for name, typ in zip(col_names, col_types)]
-        )
-
-        batches: list[pa.RecordBatch] = []
-        while True:
-            rows = cursor.fetchmany(self.batch_size)
-            if not rows:
-                break
-            col_data: dict[str, list] = {name: [] for name in col_names}
-            for row in rows:
-                for i, name in enumerate(col_names):
-                    val = row[i]
-                    if isinstance(val, decimal.Decimal):
-                        val = float(val)
-                    col_data[name].append(val)
-            batch = pa.RecordBatch.from_pydict(col_data, schema=arrow_schema)
-            batches.append(batch)
-
-        cursor.close()
-        conn.close()
-
-        if not batches:
-            return pa.table(
-                {
-                    name: pa.array([], type=typ)
-                    for name, typ in zip(col_names, col_types)
-                }
+            col_names = [desc[0] for desc in cursor.description]
+            col_types = [
+                _mysql_field_type_to_arrow(desc[1]) for desc in cursor.description
+            ]
+            arrow_schema = pa.schema(
+                [pa.field(name, typ) for name, typ in zip(col_names, col_types)]
             )
 
-        return pa.Table.from_batches(batches, schema=arrow_schema)
+            batches: list[pa.RecordBatch] = []
+            while True:
+                rows = cursor.fetchmany(self.batch_size)
+                if not rows:
+                    break
+                col_data: dict[str, list] = {name: [] for name in col_names}
+                for row in rows:
+                    for i, name in enumerate(col_names):
+                        val = row[i]
+                        if isinstance(val, decimal.Decimal):
+                            val = float(val)
+                        col_data[name].append(val)
+                batch = pa.RecordBatch.from_pydict(col_data, schema=arrow_schema)
+                batches.append(batch)
+
+            cursor.close()
+
+            if not batches:
+                return pa.table(
+                    {
+                        name: pa.array([], type=typ)
+                        for name, typ in zip(col_names, col_types)
+                    }
+                )
+
+            return pa.Table.from_batches(batches, schema=arrow_schema)
+        finally:
+            conn.close()
 
     def detect_changes(
         self, table: str, last_state: dict[str, object] | None = None
@@ -300,10 +305,11 @@ class MySQLSource(DatabaseSource):
         try:
             conn = self._connect()
             cursor = conn.cursor()
-            # CHECKSUM TABLE returns (table_name, checksum_value)
             qualified = f"{self.database}.{table}" if self.database else table
             cursor.execute(f"CHECKSUM TABLE {qualified}")
             row = cursor.fetchone()
+            cursor.execute(f"SELECT COUNT(*) FROM {qualified}")
+            count_row = cursor.fetchone()
             cursor.close()
             conn.close()
         except mysql.connector.Error:
@@ -313,21 +319,30 @@ class MySQLSource(DatabaseSource):
             return ChangeResult(changed=True, reason="first_run")
 
         current_checksum = row[1]
+        current_row_count = count_row[0] if count_row else 0
 
         if last_state is None or last_state.get("last_checksum") is None:
             return ChangeResult(
                 changed=True,
                 reason="first_run",
-                metadata={"checksum": current_checksum},
+                metadata={
+                    "checksum": current_checksum,
+                    "row_count": current_row_count,
+                },
             )
 
-        if current_checksum == last_state.get("last_checksum"):
+        if current_checksum == last_state.get(
+            "last_checksum"
+        ) and current_row_count == last_state.get("last_row_count"):
             return ChangeResult(changed=False, reason="unchanged")
 
         return ChangeResult(
             changed=True,
             reason="checksum_changed",
-            metadata={"checksum": current_checksum},
+            metadata={
+                "checksum": current_checksum,
+                "row_count": current_row_count,
+            },
         )
 
     def list_databases(self) -> list[str]:

--- a/src/feather_etl/sources/mysql.py
+++ b/src/feather_etl/sources/mysql.py
@@ -218,7 +218,21 @@ class MySQLSource(DatabaseSource):
             conn.close()
 
     def get_schema(self, table: str) -> list[tuple[str, str]]:
-        raise NotImplementedError("get_schema not yet implemented")
+        conn = self._connect()
+        try:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT COLUMN_NAME, DATA_TYPE "
+                "FROM INFORMATION_SCHEMA.COLUMNS "
+                "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+                "ORDER BY ORDINAL_POSITION",
+                (self.database, table),
+            )
+            cols = cursor.fetchall()
+            cursor.close()
+            return [(c[0], c[1]) for c in cols]
+        finally:
+            conn.close()
 
     def extract(
         self,

--- a/src/feather_etl/sources/registry.py
+++ b/src/feather_etl/sources/registry.py
@@ -20,6 +20,7 @@ SOURCE_CLASSES: dict[str, str] = {
     "sqlite": "feather_etl.sources.sqlite.SqliteSource",
     "sqlserver": "feather_etl.sources.sqlserver.SqlServerSource",
     "postgres": "feather_etl.sources.postgres.PostgresSource",
+    "mysql": "feather_etl.sources.mysql.MySQLSource",
     "excel": "feather_etl.sources.excel.ExcelSource",
     "json": "feather_etl.sources.json_source.JsonSource",
 }

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -337,3 +337,41 @@ class TestMySQLExtractIntegration:
         table = source.extract("erp_sales", filter="id = -999")
         assert isinstance(table, pa.Table)
         assert table.num_rows == 0
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.detect_changes() — integration tests (real MySQL)
+# ---------------------------------------------------------------------------
+
+
+@mysql_db
+class TestMySQLDetectChangesIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_detect_changes_first_run(self, source):
+        result = source.detect_changes("erp_sales", last_state=None)
+        assert result.changed is True
+        assert result.reason == "first_run"
+        assert "checksum" in result.metadata
+
+    def test_detect_changes_unchanged(self, source):
+        first = source.detect_changes("erp_sales", last_state=None)
+        last_state = {
+            "last_checksum": first.metadata.get("checksum"),
+        }
+        second = source.detect_changes("erp_sales", last_state=last_state)
+        assert second.changed is False
+        assert second.reason == "unchanged"
+
+    def test_detect_changes_incremental_always_changed(self, source):
+        last_state = {"strategy": "incremental"}
+        result = source.detect_changes("erp_sales", last_state=last_state)
+        assert result.changed is True
+        assert result.reason == "incremental"

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -158,6 +158,23 @@ class TestMySQLValidateSourceTable:
 # ---------------------------------------------------------------------------
 
 
+MYSQL_CONN_KWARGS = {"host": "localhost", "user": "root", "database": "feather_test"}
+
+
+def _mysql_available() -> bool:
+    try:
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_CONN_KWARGS)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+mysql_db = pytest.mark.skipif(not _mysql_available(), reason="MySQL not available")
+
+
 class TestMySQLCheckLastError:
     def test_check_failure_populates_last_error(self, monkeypatch):
         from feather_etl.sources import mysql as mysql_mod
@@ -191,3 +208,44 @@ class TestMySQLCheckLastError:
         )
         assert src.check() is True
         assert src._last_error is None
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.discover() — integration tests (real MySQL)
+# ---------------------------------------------------------------------------
+
+
+@mysql_db
+class TestMySQLDiscoverIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_discover_returns_erp_tables(self, source):
+        schemas = source.discover()
+        names = {s.name for s in schemas}
+        assert "erp_customers" in names
+        assert "erp_products" in names
+        assert "erp_sales" in names
+
+    def test_discover_schema_fields(self, source):
+        schemas = source.discover()
+        sales = next(s for s in schemas if s.name == "erp_sales")
+        assert sales.supports_incremental is True
+        assert sales.primary_key is None
+        col_names = [c[0] for c in sales.columns]
+        assert "id" in col_names
+        assert "amount" in col_names
+
+    def test_discover_column_types(self, source):
+        schemas = source.discover()
+        sales = next(s for s in schemas if s.name == "erp_sales")
+        col_types = {c[0]: c[1] for c in sales.columns}
+        assert col_types["id"] == "int"
+        assert col_types["product"] == "varchar"
+        assert col_types["amount"] == "decimal"

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -249,3 +249,36 @@ class TestMySQLDiscoverIntegration:
         assert col_types["id"] == "int"
         assert col_types["product"] == "varchar"
         assert col_types["amount"] == "decimal"
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.get_schema() — integration tests (real MySQL)
+# ---------------------------------------------------------------------------
+
+
+@mysql_db
+class TestMySQLGetSchemaIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_get_schema_returns_columns(self, source):
+        cols = source.get_schema("erp_sales")
+        col_names = [c[0] for c in cols]
+        assert "id" in col_names
+        assert "customer_id" in col_names
+        assert "product" in col_names
+        assert "amount" in col_names
+        assert "modified_at" in col_names
+
+    def test_get_schema_returns_types(self, source):
+        cols = source.get_schema("erp_sales")
+        col_types = {c[0]: c[1] for c in cols}
+        assert col_types["id"] == "int"
+        assert col_types["amount"] == "decimal"
+        assert col_types["modified_at"] == "timestamp"

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -1,0 +1,193 @@
+"""Tests for MySQL source.
+
+Real-database tests are marked with a skip decorator and are skipped when
+the local MySQL instance is not reachable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.from_yaml — unit tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLFromYaml:
+    def test_minimal_entry_builds_connect_kwargs(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "db.example.com",
+            "user": "u",
+            "password": "p",
+            "database": "warehouse",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.name == "wh"
+        assert src.host == "db.example.com"
+        assert src.port == 3306
+        assert src.database == "warehouse"
+        assert src._connect_kwargs["host"] == "db.example.com"
+        assert src._connect_kwargs["port"] == 3306
+        assert src._connect_kwargs["database"] == "warehouse"
+        assert src._connect_kwargs["user"] == "u"
+        assert src._connect_kwargs["password"] == "p"
+
+    def test_explicit_port(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "h",
+            "port": 3307,
+            "user": "u",
+            "password": "p",
+            "database": "X",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.port == 3307
+        assert src._connect_kwargs["port"] == 3307
+
+    def test_explicit_connection_string(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        entry = {
+            "name": "wh",
+            "type": "mysql",
+            "connection_string": "host=raw;database=verbatim",
+        }
+        src = MySQLSource.from_yaml(entry, Path("."))
+        assert src.connection_string == "host=raw;database=verbatim"
+
+    def test_databases_list_and_xor_rules(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        ok = {
+            "name": "wh",
+            "type": "mysql",
+            "host": "h",
+            "user": "u",
+            "password": "p",
+            "databases": ["A", "B"],
+        }
+        src = MySQLSource.from_yaml(ok, Path("."))
+        assert src.databases == ["A", "B"]
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            MySQLSource.from_yaml({**ok, "database": "C"}, Path("."))
+
+        with pytest.raises(ValueError, match="non-empty"):
+            MySQLSource.from_yaml({**ok, "databases": []}, Path("."))
+
+    def test_missing_host_and_connection_string_raises(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        with pytest.raises(ValueError, match="requires either"):
+            MySQLSource.from_yaml({"name": "x", "type": "mysql"}, Path("."))
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource — unit tests (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLSourceUnit:
+    def test_source_type_is_mysql(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        assert MySQLSource.type == "mysql"
+
+    def test_watermark_passthrough(self):
+        """MySQLSource uses the default _format_watermark (ISO unchanged)."""
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        assert src._format_watermark("2026-01-01T10:00:00") == "2026-01-01T10:00:00"
+
+    def test_build_where_filter_only(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(filter="active = 1")
+        assert result == " WHERE (active = 1)"
+
+    def test_build_where_watermark_only(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(
+            watermark_column="modified_at", watermark_value="2026-01-01"
+        )
+        assert result == " WHERE modified_at > '2026-01-01'"
+
+    def test_build_where_both(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        result = src._build_where_clause(
+            filter="active = 1",
+            watermark_column="modified_at",
+            watermark_value="2026-01-01",
+        )
+        assert result == " WHERE (active = 1) AND modified_at > '2026-01-01'"
+
+
+class TestMySQLValidateSourceTable:
+    def test_plain_table_ok(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy", name="x")
+        assert src.validate_source_table("orders") == []
+
+    def test_qualified_table_ok(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy", name="x")
+        assert src.validate_source_table("mydb.orders") == []
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.check() — unit tests (mocked connector)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLCheckLastError:
+    def test_check_failure_populates_last_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        def boom(**kwargs):
+            raise mysql_mod.mysql.connector.Error("Access denied for user 'root'")
+
+        monkeypatch.setattr(mysql_mod.mysql.connector, "connect", boom)
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "nope"}
+        assert src.check() is False
+        assert src._last_error is not None
+        assert "Access denied" in src._last_error
+
+    def test_check_success_clears_last_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "localhost"}
+        src._last_error = "stale error from a prior call"
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            mysql_mod.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        assert src.check() is True
+        assert src._last_error is None

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -375,3 +375,62 @@ class TestMySQLDetectChangesIntegration:
         result = source.detect_changes("erp_sales", last_state=last_state)
         assert result.changed is True
         assert result.reason == "incremental"
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.list_databases — unit tests (mocked connector)
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLListDatabases:
+    def test_query_filters_system_dbs(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        captured_sql: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                captured_sql.append(sql)
+
+            def fetchall(self):
+                return [("warehouse",), ("analytics",)]
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            mysql_mod.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "localhost"}
+        result = src.list_databases()
+
+        assert result == ["warehouse", "analytics"]
+        sql = captured_sql[0]
+        assert "SCHEMA_NAME" in sql
+        assert "information_schema" in sql
+        assert "mysql" in sql
+        assert "performance_schema" in sql
+        assert "sys" in sql
+
+    def test_propagates_connector_error(self, monkeypatch):
+        from feather_etl.sources import mysql as mysql_mod
+        from feather_etl.sources.mysql import MySQLSource
+
+        def raise_(**k):
+            raise mysql_mod.mysql.connector.Error("connection refused")
+
+        monkeypatch.setattr(mysql_mod.mysql.connector, "connect", raise_)
+        src = MySQLSource(connection_string="dummy")
+        src._connect_kwargs = {"host": "nope"}
+        with pytest.raises(mysql_mod.mysql.connector.Error):
+            src.list_databases()

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -360,11 +360,13 @@ class TestMySQLDetectChangesIntegration:
         assert result.changed is True
         assert result.reason == "first_run"
         assert "checksum" in result.metadata
+        assert "row_count" in result.metadata
 
     def test_detect_changes_unchanged(self, source):
         first = source.detect_changes("erp_sales", last_state=None)
         last_state = {
             "last_checksum": first.metadata.get("checksum"),
+            "last_row_count": first.metadata.get("row_count"),
         }
         second = source.detect_changes("erp_sales", last_state=last_state)
         assert second.changed is False
@@ -434,3 +436,30 @@ class TestMySQLListDatabases:
         src._connect_kwargs = {"host": "nope"}
         with pytest.raises(mysql_mod.mysql.connector.Error):
             src.list_databases()
+
+
+# ---------------------------------------------------------------------------
+# Registry — unit test
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLRegistry:
+    def test_source_in_registry(self):
+        from feather_etl.sources.mysql import MySQLSource
+        from feather_etl.sources.registry import get_source_class
+
+        assert get_source_class("mysql") is MySQLSource
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.discover() — guard when database is None
+# ---------------------------------------------------------------------------
+
+
+class TestMySQLDiscoverGuard:
+    def test_discover_without_database_raises(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="dummy")
+        with pytest.raises(ValueError, match="requires database"):
+            src.discover()

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -282,3 +282,58 @@ class TestMySQLGetSchemaIntegration:
         assert col_types["id"] == "int"
         assert col_types["amount"] == "decimal"
         assert col_types["modified_at"] == "timestamp"
+
+
+# ---------------------------------------------------------------------------
+# MySQLSource.extract() — integration tests (real MySQL)
+# ---------------------------------------------------------------------------
+
+
+@mysql_db
+class TestMySQLExtractIntegration:
+    @pytest.fixture
+    def source(self):
+        from feather_etl.sources.mysql import MySQLSource
+
+        src = MySQLSource(connection_string="")
+        src._connect_kwargs = MYSQL_CONN_KWARGS
+        src.database = "feather_test"
+        return src
+
+    def test_extract_full(self, source):
+        import pyarrow as pa
+
+        table = source.extract("erp_sales")
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 10
+        assert "id" in table.column_names
+        assert "amount" in table.column_names
+
+    def test_extract_with_columns(self, source):
+        table = source.extract("erp_customers", columns=["id", "name"])
+        assert table.column_names == ["id", "name"]
+        assert table.num_rows == 4
+
+    def test_extract_with_filter(self, source):
+        table = source.extract("erp_sales", filter="amount > 150")
+        assert table.num_rows > 0
+        amounts = table.column("amount").to_pylist()
+        assert all(a > 150 for a in amounts)
+
+    def test_extract_incremental_with_watermark(self, source):
+        import pyarrow as pa
+
+        table = source.extract(
+            "erp_sales",
+            watermark_column="modified_at",
+            watermark_value="2026-01-03",
+        )
+        assert isinstance(table, pa.Table)
+        assert table.num_rows > 0
+
+    def test_extract_empty_result(self, source):
+        import pyarrow as pa
+
+        table = source.extract("erp_sales", filter="id = -999")
+        assert isinstance(table, pa.Table)
+        assert table.num_rows == 0

--- a/uv.lock
+++ b/uv.lock
@@ -210,6 +210,7 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
+    { name = "mysql-connector-python" },
     { name = "psycopg2-binary" },
     { name = "pyarrow" },
     { name = "pyodbc" },
@@ -228,6 +229,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "duckdb", specifier = ">=1.0" },
+    { name = "mysql-connector-python", specifier = ">=8.0" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pyarrow", specifier = ">=15.0" },
     { name = "pyodbc", specifier = ">=5.0" },
@@ -271,6 +273,40 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mysql-connector-python"
+version = "9.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/27/106f5b7a69381c58cb0ba6bf44e6488969ce6cd9f69f62df340f379141ee/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:478e035ebcf734b3a1497bfd3eb72ce3632da6384545b08cf6329471b3849b6e", size = 17582676, upload-time = "2026-01-21T09:04:35.755Z" },
+    { url = "https://files.pythonhosted.org/packages/17/97/d3cbab27663d7b5063d891c6bd322db6cf1cdb42d4e0d2d2ec9a1952c67f/mysql_connector_python-9.6.0-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:228000bb951810dad724821d04000174ffcc7fa94b4dcef884b17a3cdae07283", size = 18449353, upload-time = "2026-01-21T09:04:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/0e14e30dddb8f9a5230c6dbce6f874fba2aeaab1ce971dce3912cf81773e/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:477e86182aefbf693b71ff8bda7679ab4487af64c027759af831a70080aaaeac", size = 34161450, upload-time = "2026-01-21T09:04:40.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/80/1b0012fd86b5a7c0952878e33938ccd4b2862eb882e08a502b99348988d0/mysql_connector_python-9.6.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:4bf932724a2702d8b9cde4bf764b843a35e85c59479a870997d37a2a68a5632d", size = 34533941, upload-time = "2026-01-21T09:04:43.759Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ed/9ff5ff9ea8421ffdf248fa71b9328fd8b9a23e1e3a2a523db5f7d58240c6/mysql_connector_python-9.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:b507372c060eb39e2a10ebcb3eb1b12e1778b0120808062fc23e3856268cd2d9", size = 16515417, upload-time = "2026-01-21T09:04:46.47Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/08/0e9bce000736454c2b8bb4c40bded79328887483689487dad7df4cf59fb7/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:011931f7392a1087e10d305b0303f2a20cc1af2c1c8a15cd5691609aa95dfcbd", size = 17582646, upload-time = "2026-01-21T09:04:48.327Z" },
+    { url = "https://files.pythonhosted.org/packages/93/aa/3dd4db039fc6a9bcbdbade83be9914ead6786c0be4918170dfaf89327b76/mysql_connector_python-9.6.0-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:b5212372aff6833473d2560ac87d3df9fb2498d0faacb7ebf231d947175fa36a", size = 18449358, upload-time = "2026-01-21T09:04:50.278Z" },
+    { url = "https://files.pythonhosted.org/packages/53/38/ecd6d35382b6265ff5f030464d53b45e51ff2c2523ab88771c277fd84c05/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:61deca6e243fafbb3cf08ae27bd0c83d0f8188de8456e46aeba0d3db15bb7230", size = 34169309, upload-time = "2026-01-21T09:04:52.402Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1d/fe1133eb76089342854d8fbe88e28598f7e06bc684a763d21fc7b23f1d5e/mysql_connector_python-9.6.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:adabbc5e1475cdf5fb6f1902a25edc3bd1e0726fa45f01ab1b8f479ff43b3337", size = 34541101, upload-time = "2026-01-21T09:04:55.897Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/99/da0f55beb970ca049fd7d37a6391d686222af89a8b13e636d8e9bbd06536/mysql_connector_python-9.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:8732ca0b7417b45238bcbfc7e64d9c4d62c759672207c6284f0921c366efddc7", size = 16514767, upload-time = "2026-02-10T12:03:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d9/2a4b4d90b52f4241f0f71618cd4bd8779dd6d18db8058b0a4dd83ec0541c/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9664e217c72dd6fb700f4c8512af90261f72d2f5d7c00c4e13e4c1e09bfa3d5e", size = 17585672, upload-time = "2026-02-10T12:03:52.955Z" },
+    { url = "https://files.pythonhosted.org/packages/33/91/2495835733a054e716a17dc28404748b33f2dc1da1ae4396fb45574adf40/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1ed4b5c4761e5333035293e746683890e4ef2e818e515d14023fd80293bc31fa", size = 18452624, upload-time = "2026-02-10T12:03:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/69/e83abbbbf7f8eed855b5a5ff7285bc0afb1199418ac036c7691edf41e154/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5095758dcb89a6bce2379f349da336c268c407129002b595c5dba82ce387e2a5", size = 34169154, upload-time = "2026-02-10T12:03:58.831Z" },
+    { url = "https://files.pythonhosted.org/packages/82/44/67bb61c71f398fbc739d07e8dcadad94e2f655874cb32ae851454066bea0/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ae4e7780fad950a4f267dea5851048d160f5b71314a342cdbf30b154f1c74f7", size = 34542947, upload-time = "2026-02-10T12:04:02.408Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/39/994c4f7e9c59d3ca534a831d18442ac4c529865db20aeaa4fd94e2af5efd/mysql_connector_python-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c180e0b4100d7402e03993bfac5c97d18e01d7ca9d198d742fffc245077f8ffe", size = 16515709, upload-time = "2026-02-10T12:04:04.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/58/9521aa678708ec6cebfd40524c14c3d151e4f29e3774e6086aa0a30d203b/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e86e45a7b540ca09af8a18ecfa761e0cdeccfdb62818331614ec030ae44bfd26", size = 17585837, upload-time = "2026-02-10T12:04:07.004Z" },
+    { url = "https://files.pythonhosted.org/packages/39/8d/b108f9bcce9780f6a1f91decb2af54defdaf845e237ddc42f2b4578f1cd7/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:8d3e9252384e1b7f95b07020664f2673d9c29c5e95eeda2e048b3331e190b9d4", size = 18452844, upload-time = "2026-02-10T12:04:09.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/28/735cd93d16e76dc2feb4abb3f1229a1d9475af34d80c26712fec6abe1d70/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0fa18ead33cb699ea92005695077cef09aa494eebf51164ee30c891c3eaea90c", size = 34169374, upload-time = "2026-02-10T12:04:12.13Z" },
+    { url = "https://files.pythonhosted.org/packages/42/07/069983799cf4050c68f61a494f94b06f095fee6026ab0dd863a14de30867/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a26490cb029bf7b18a1d2093101105b3526a1036b51ad01553d30138f5beb8d2", size = 34543019, upload-time = "2026-02-10T12:04:15.065Z" },
+    { url = "https://files.pythonhosted.org/packages/32/00/fbeb7d666ab8153f719e620bac5abfbc74640e8ec511612493110a75fe66/mysql_connector_python-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:3460ed976e1b88b7284335d9397a3c519dff56d71580ca1f76ff1c0c7714c813", size = 16515701, upload-time = "2026-02-10T12:04:19.26Z" },
+    { url = "https://files.pythonhosted.org/packages/70/51/13cc90b2a703784cd9a0aa0a6fce07946cf6a2abe7c8fd0b585562e250fc/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e2cc13cd3dcdb845d636e52c4e7a9509b63da09bec6ce1b3696be53a79847e2d", size = 17585800, upload-time = "2026-02-10T12:04:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/6b/ce7ab998fbdd17f35a1b54624365d039045cbb2d42bbc7b03f50d7597c7b/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:a08c2149d4b52a010c4353f18c84716d18114a4ecd00b466ea34138de2c640f2", size = 18452823, upload-time = "2026-02-10T12:04:23.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/8157ed61d17878c33511dcb97c68ecaaaf6220bea5a2944ea4eba73cc63a/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b00228b985edd208b20f45c5e684c54e08e31e01bc1d8c3c18a36641c3be5bf7", size = 34171594, upload-time = "2026-02-10T12:04:27.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
+    { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `MySQLSource` class extending `DatabaseSource` with full Source protocol implementation
- Uses `mysql-connector-python` (pure Python, no system deps)
- Supports `host/port/user/password/database` config, `connection_string:` override, and `databases:` list for multi-DB discovery
- 31 tests (14 unit + 17 integration) — all passing, 613 total suite green
- Fix `_expand_db_sources` to include `MySQLSource` in database expansion (#27)

## Files changed

| File | Change |
|---|---|
| `src/feather_etl/sources/mysql.py` | New — MySQLSource class (~260 lines) |
| `tests/test_mysql.py` | New — 31 tests (~460 lines) |
| `src/feather_etl/sources/registry.py` | 1 line — add `"mysql"` entry |
| `src/feather_etl/commands/discover.py` | 2 lines — include MySQLSource in db expansion |
| `pyproject.toml` | 1 line — add `mysql-connector-python>=8.0` |
| `docs/plans/` | 2 new plan docs |

## YAML config

```yaml
sources:
  - name: my_erp
    type: mysql
    host: db.example.com
    port: 3306
    user: analyst
    password: ${MYSQL_PASSWORD}
    database: erp_db
```

## Test plan

- [x] 14 unit tests pass (no MySQL needed)
- [x] 17 integration tests pass (local MySQL with `feather_test` fixture DB)
- [x] Full suite: 613 passed, 16 skipped
- [x] ruff check + format clean
- [x] Tested against real MySQL server (192.168.2.77) via `feather discover` in rama_dw project

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)