### PR TITLE
feat: multi-source pipeline + curation-driven extraction (#8, #15, #27)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-multi-source-pipeline.md
+++ b/docs/superpowers/plans/2026-04-18-multi-source-pipeline.md
@@ -1,0 +1,1219 @@
+# Multi-Source Pipeline + Curation-Driven Extraction — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `feather run` extract tables from multiple sources using `discovery/curation.json` as the table manifest, replacing the YAML `tables:` section.
+
+**Architecture:** Config-layer resolution — `load_config()` reads curation.json, filters to `include` entries, resolves each entry's `source_db` to the correct source instance, and produces `TableConfig` objects with resolved source references. Pipeline receives a source per table instead of hardcoding `sources[0]`.
+
+**Tech Stack:** Python, DuckDB, PyArrow, pytest (file-based fixtures only — no database server deps)
+
+**Spec:** `docs/superpowers/specs/2026-04-18-multi-source-pipeline-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Status |
+|---|---|---|
+| `src/feather_etl/sources/expand.py` | Shared `expand_db_sources()` using `DatabaseSource` base class | **New** |
+| `src/feather_etl/curation.py` | Load curation.json, filter to includes, resolve source_db, produce TableConfig list | **New** |
+| `tests/test_expand_db_sources.py` | Tests for extracted expand utility | **New** |
+| `tests/test_curation.py` | Tests for curation loader + source resolution | **New** |
+| `tests/test_multi_source_e2e.py` | End-to-end multi-source extraction with file-based sources | **New** |
+| `src/feather_etl/config.py` | Add `source`/`database` to TableConfig, wire curation loader | **Modify** |
+| `src/feather_etl/pipeline.py` | `run_table()` accepts source param | **Modify** |
+| `src/feather_etl/commands/_common.py` | Remove `_enforce_single_source()` | **Modify** |
+| `src/feather_etl/commands/run.py` | Remove gate, pass source to pipeline | **Modify** |
+| `src/feather_etl/commands/setup.py` | Remove gate | **Modify** |
+| `src/feather_etl/commands/status.py` | Remove gate | **Modify** |
+| `src/feather_etl/commands/validate.py` | Remove gate, iterate all sources for check | **Modify** |
+| `src/feather_etl/commands/history.py` | Remove gate | **Modify** |
+| `src/feather_etl/commands/discover.py` | Import from shared expand utility | **Modify** |
+
+---
+
+### Task 1: Extract `_expand_db_sources` to shared utility
+
+**Files:**
+- Create: `src/feather_etl/sources/expand.py`
+- Create: `tests/test_expand_db_sources.py`
+- Modify: `src/feather_etl/commands/discover.py:37-97`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_expand_db_sources.py`:
+
+```python
+"""Tests for the shared expand_db_sources utility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class TestExpandDbSources:
+    def test_file_sources_pass_through(self):
+        """File sources are returned unchanged."""
+        from feather_etl.sources.expand import expand_db_sources
+
+        mock_src = MagicMock()
+        mock_src.database = None
+        mock_src.databases = None
+        # Not a DatabaseSource subclass — simulate a FileSource
+        result = expand_db_sources([mock_src])
+        assert result == [mock_src]
+
+    def test_db_source_with_single_database_passes_through(self):
+        """DB source with database set is returned unchanged."""
+        from feather_etl.sources.expand import expand_db_sources
+        from feather_etl.sources.database_source import DatabaseSource
+
+        mock_src = MagicMock(spec=DatabaseSource)
+        mock_src.database = "mydb"
+        mock_src.databases = None
+        result = expand_db_sources([mock_src])
+        assert result == [mock_src]
+
+    def test_db_source_with_databases_list_expands(self):
+        """DB source with databases: [a, b] produces one child per db."""
+        from feather_etl.sources.expand import expand_db_sources
+        from feather_etl.sources.database_source import DatabaseSource
+
+        mock_src = MagicMock(spec=DatabaseSource)
+        mock_src.database = None
+        mock_src.databases = ["db_a", "db_b"]
+        mock_src.name = "test_server"
+        mock_src.type = "sqlserver"
+        mock_src.host = "localhost"
+        mock_src.port = 1433
+        mock_src.user = "sa"
+        mock_src.password = "pass"
+        mock_src._explicit_name = False
+
+        child_a = MagicMock(spec=DatabaseSource)
+        child_b = MagicMock(spec=DatabaseSource)
+        type(mock_src).from_yaml = MagicMock(side_effect=[child_a, child_b])
+
+        result = expand_db_sources([mock_src])
+        assert len(result) == 2
+        calls = type(mock_src).from_yaml.call_args_list
+        assert calls[0][0][0]["database"] == "db_a"
+        assert calls[0][0][0]["name"] == "test_server__db_a"
+        assert calls[1][0][0]["database"] == "db_b"
+        assert calls[1][0][0]["name"] == "test_server__db_b"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_expand_db_sources.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'feather_etl.sources.expand'`
+
+- [ ] **Step 3: Write the shared expand utility**
+
+Create `src/feather_etl/sources/expand.py`:
+
+```python
+"""Shared database source expansion — used by discover and pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.sources.database_source import DatabaseSource
+
+
+def expand_db_sources(sources: list) -> list:
+    """Expand database sources without explicit database into child sources.
+
+    For each source:
+      - File sources → keep as-is.
+      - DB source with `database` set → keep as-is.
+      - DB source with `databases: [...]` → one child per entry.
+      - DB source with neither → call list_databases() and expand.
+    """
+    expanded: list = []
+    for src in sources:
+        if not isinstance(src, DatabaseSource):
+            expanded.append(src)
+            continue
+        if src.database is not None:
+            expanded.append(src)
+            continue
+        databases = src.databases
+        if databases is None:
+            try:
+                databases = src.list_databases()
+            except Exception as e:
+                src._last_error = (
+                    f"Found 0 databases on host {src.host}. Either grant "
+                    f"VIEW ANY DATABASE to this login, or specify "
+                    f"`database:` / `databases: [...]` explicitly. ({e})"
+                )
+                expanded.append(src)
+                continue
+            if not databases:
+                src._last_error = (
+                    f"Found 0 databases on host {src.host}. Either grant "
+                    f"VIEW ANY DATABASE to this login, or specify "
+                    f"`database:` / `databases: [...]` explicitly."
+                )
+                expanded.append(src)
+                continue
+        for db in databases:
+            child = type(src).from_yaml(
+                {
+                    "name": f"{src.name}__{db}",
+                    "type": src.type,
+                    "host": src.host,
+                    "port": src.port,
+                    "user": src.user,
+                    "password": src.password,
+                    "database": db,
+                },
+                Path("."),
+            )
+            child._explicit_name = getattr(src, "_explicit_name", False)
+            expanded.append(child)
+    return expanded
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_expand_db_sources.py -v`
+Expected: 3 tests PASS
+
+- [ ] **Step 5: Update discover.py to import from shared utility**
+
+In `src/feather_etl/commands/discover.py`, replace the `_expand_db_sources` function (lines 37–97) with an import:
+
+```python
+from feather_etl.sources.expand import expand_db_sources
+```
+
+Update the call site at line 139 from `_expand_db_sources(cfg.sources)` to `expand_db_sources(cfg.sources)`.
+
+Delete the old `_expand_db_sources` function and its three `from feather_etl.sources.*` imports at lines 48–51.
+
+- [ ] **Step 6: Run full test suite to confirm no regressions**
+
+Run: `uv run pytest -q`
+Expected: All tests pass (currently 597)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/feather_etl/sources/expand.py tests/test_expand_db_sources.py src/feather_etl/commands/discover.py
+git commit -m "refactor: extract expand_db_sources to shared utility, use DatabaseSource base class (#27)"
+```
+
+---
+
+### Task 2: Add `source` and `database` fields to `TableConfig`
+
+**Files:**
+- Modify: `src/feather_etl/config.py:85-99`
+
+- [ ] **Step 1: Add fields to TableConfig**
+
+In `src/feather_etl/config.py`, add two fields to the `TableConfig` dataclass after `dedup_columns`:
+
+```python
+@dataclass
+class TableConfig:
+    name: str
+    source_table: str
+    strategy: str
+    target_table: str = ""
+    primary_key: list[str] | None = None
+    timestamp_column: str | None = None
+    checksum_columns: list[str] | None = None
+    filter: str | None = None
+    quality_checks: dict | None = None
+    column_map: dict[str, str] | None = None
+    schedule: str | None = None
+    dedup: bool = False
+    dedup_columns: list[str] | None = None
+    source_name: str | None = None    # resolved source name from curation
+    database: str | None = None       # resolved database from curation
+```
+
+- [ ] **Step 2: Run full test suite to confirm backward compat**
+
+Run: `uv run pytest -q`
+Expected: All tests pass — new fields have `None` defaults so nothing breaks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/feather_etl/config.py
+git commit -m "feat: add source_name and database fields to TableConfig (#8)"
+```
+
+---
+
+### Task 3: Build curation.json loader
+
+**Files:**
+- Create: `src/feather_etl/curation.py`
+- Create: `tests/test_curation.py`
+
+- [ ] **Step 1: Write tests for curation loader**
+
+Create `tests/test_curation.py`:
+
+```python
+"""Tests for curation.json loader and source resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from feather_etl.config import TableConfig
+
+
+def _write_curation(tmp_path: Path, tables: list[dict], source_systems: dict | None = None) -> Path:
+    """Write a minimal curation.json for testing."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": source_systems or {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    path = discovery_dir / "curation.json"
+    path.write_text(json.dumps(manifest, indent=2))
+    return path
+
+
+def _make_include_entry(
+    source_db: str = "test_db",
+    source_table: str = "dbo.Sales",
+    alias: str = "sales",
+    strategy: str = "full",
+    primary_key: list[str] | None = None,
+    timestamp: dict | None = None,
+) -> dict:
+    return {
+        "source_db": source_db,
+        "source_table": source_table,
+        "decision": "include",
+        "table_type": "fact",
+        "group": "test",
+        "alias": alias,
+        "classification_notes": None,
+        "strategy": strategy,
+        "primary_key": primary_key or ["id"],
+        "timestamp": timestamp,
+        "grain": None,
+        "scd": None,
+        "mapping": None,
+        "dq_policy": None,
+        "load_contract": None,
+        "reason": "test entry",
+    }
+
+
+class TestLoadCuration:
+    def test_filters_to_include_only(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(alias="sales"),
+            {**_make_include_entry(alias="excluded"), "decision": "exclude"},
+            {**_make_include_entry(alias="review"), "decision": "review"},
+        ]
+        _write_curation(tmp_path, tables)
+        result = load_curation_tables(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "test_db_sales"
+
+    def test_derives_bronze_name_from_source_db_and_alias(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="Gofrugal", alias="sales")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].name == "gofrugal_sales"
+        assert result[0].target_table == "bronze.gofrugal_sales"
+
+    def test_maps_strategy(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(strategy="incremental", timestamp={"column": "SyncDate", "reason": None, "rejected": []})
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].strategy == "incremental"
+        assert result[0].timestamp_column == "SyncDate"
+
+    def test_maps_primary_key(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(primary_key=["record_no", "line_no"])
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].primary_key == ["record_no", "line_no"]
+
+    def test_sets_source_name_and_database(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="SAP")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].database == "SAP"
+
+    def test_missing_curation_raises(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        with pytest.raises(FileNotFoundError, match="discovery/curation.json"):
+            load_curation_tables(tmp_path)
+
+    def test_no_include_entries_raises(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = {**_make_include_entry(), "decision": "exclude"}
+        _write_curation(tmp_path, [entry])
+        with pytest.raises(ValueError, match="No tables with decision.*include"):
+            load_curation_tables(tmp_path)
+
+    def test_sanitizes_bronze_name(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="My-Source", alias="Sales Data!")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        # Should be lowercased and sanitized
+        assert result[0].name == "my_source_sales_data_"
+
+
+class TestResolveSource:
+    def test_resolves_source_by_databases_list(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "Rama"
+        mock_src.database = None
+        mock_src.databases = ["Gofrugal", "SAP", "ZAKYA"]
+        mock_src.type = "sqlserver"
+
+        result = resolve_source("Gofrugal", [mock_src])
+        assert result == mock_src
+
+    def test_resolves_source_by_single_database(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "erp"
+        mock_src.database = "mydb"
+        mock_src.databases = None
+
+        result = resolve_source("mydb", [mock_src])
+        assert result == mock_src
+
+    def test_resolves_file_source_by_name(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "csv_data"
+        mock_src.database = None
+        mock_src.databases = None
+        # File source — no database attribute logic, matched by name
+        del mock_src.database
+        del mock_src.databases
+        mock_src.name = "csv_data"
+
+        result = resolve_source("csv_data", [mock_src])
+        assert result == mock_src
+
+    def test_no_match_raises(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "Rama"
+        mock_src.database = None
+        mock_src.databases = ["Gofrugal"]
+
+        with pytest.raises(ValueError, match="does not match any declared source"):
+            resolve_source("NonExistent", [mock_src])
+
+    def test_ambiguous_match_raises(self):
+        from feather_etl.curation import resolve_source
+
+        src_a = MagicMock()
+        src_a.name = "ServerA"
+        src_a.database = None
+        src_a.databases = ["sales"]
+
+        src_b = MagicMock()
+        src_b.name = "ServerB"
+        src_b.database = None
+        src_b.databases = ["sales"]
+
+        with pytest.raises(ValueError, match="ambiguous.*matches multiple sources"):
+            resolve_source("sales", [src_a, src_b])
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_curation.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'feather_etl.curation'`
+
+- [ ] **Step 3: Implement the curation loader**
+
+Create `src/feather_etl/curation.py`:
+
+```python
+"""Curation manifest loader — reads discovery/curation.json as the table manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from feather_etl.config import TableConfig
+
+_UNSAFE_CHARS = re.compile(r"[^a-z0-9_]")
+
+
+def _sanitize_bronze_name(source_db: str, alias: str) -> str:
+    """Derive a sanitized bronze table name from source_db and alias.
+
+    Format: <source_db>_<alias>, lowercased, non-alphanum replaced with underscore.
+    """
+    raw = f"{source_db}_{alias}".lower()
+    return _UNSAFE_CHARS.sub("_", raw)
+
+
+def resolve_source(source_db: str, sources: list) -> object:
+    """Find the source that owns the given database name.
+
+    Resolution order:
+    1. source.database == source_db (single-database source)
+    2. source_db in source.databases (multi-database source)
+    3. source.name == source_db (file sources — no database concept)
+
+    Raises ValueError if no match or ambiguous match.
+    """
+    matches = []
+    for src in sources:
+        db = getattr(src, "database", None)
+        dbs = getattr(src, "databases", None)
+        if db is not None and db == source_db:
+            matches.append(src)
+        elif dbs is not None and source_db in dbs:
+            matches.append(src)
+        elif src.name == source_db:
+            matches.append(src)
+
+    if len(matches) == 0:
+        available = ", ".join(s.name for s in sources)
+        raise ValueError(
+            f"source_db '{source_db}' does not match any declared source. "
+            f"Available sources: {available}"
+        )
+    if len(matches) > 1:
+        names = ", ".join(s.name for s in matches)
+        raise ValueError(
+            f"source_db '{source_db}' is ambiguous — matches multiple sources: {names}"
+        )
+    return matches[0]
+
+
+def load_curation_tables(config_dir: Path) -> list[TableConfig]:
+    """Load discovery/curation.json and produce TableConfig list from include entries.
+
+    Raises FileNotFoundError if curation.json does not exist.
+    Raises ValueError if no tables have decision 'include'.
+    """
+    curation_path = config_dir / "discovery" / "curation.json"
+    if not curation_path.exists():
+        raise FileNotFoundError(
+            f"discovery/curation.json not found in {config_dir}. "
+            f"Run 'feather discover' and curate tables first."
+        )
+
+    manifest = json.loads(curation_path.read_text())
+    raw_tables = manifest.get("tables", [])
+    includes = [t for t in raw_tables if t.get("decision") == "include"]
+
+    if not includes:
+        raise ValueError(
+            "No tables with decision 'include' in discovery/curation.json. "
+            "Curate at least one table before running."
+        )
+
+    tables: list[TableConfig] = []
+    for entry in includes:
+        source_db = entry["source_db"]
+        alias = entry.get("alias") or entry["source_table"].split(".")[-1]
+        bronze_name = _sanitize_bronze_name(source_db, alias)
+
+        timestamp_column = None
+        ts = entry.get("timestamp")
+        if ts and isinstance(ts, dict):
+            timestamp_column = ts.get("column")
+
+        tables.append(
+            TableConfig(
+                name=bronze_name,
+                source_table=entry["source_table"],
+                strategy=entry["strategy"],
+                target_table=f"bronze.{bronze_name}",
+                primary_key=entry.get("primary_key"),
+                timestamp_column=timestamp_column,
+                source_name=source_db,
+                database=source_db,
+            )
+        )
+
+    return tables
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_curation.py -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/curation.py tests/test_curation.py
+git commit -m "feat: add curation.json loader with source resolution (#8, #15)"
+```
+
+---
+
+### Task 4: Wire curation loader into `load_config()`
+
+**Files:**
+- Modify: `src/feather_etl/config.py:274-418`
+- Create: `tests/test_curation_config_integration.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `tests/test_curation_config_integration.py`:
+
+```python
+"""Tests for curation.json integration with load_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+import yaml
+
+
+def _write_feather_yaml(tmp_path: Path, sources: list[dict]) -> Path:
+    """Write a feather.yaml with sources and destination, no tables."""
+    config = {
+        "sources": sources,
+        "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+    }
+    config_file = tmp_path / "feather.yaml"
+    config_file.write_text(yaml.dump(config, default_flow_style=False))
+    return config_file
+
+
+def _write_curation(tmp_path: Path, tables: list[dict]) -> None:
+    """Write discovery/curation.json."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    (discovery_dir / "curation.json").write_text(json.dumps(manifest))
+
+
+def _make_include(source_db: str, source_table: str, alias: str, strategy: str = "full") -> dict:
+    return {
+        "source_db": source_db,
+        "source_table": source_table,
+        "decision": "include",
+        "table_type": "fact",
+        "group": "test",
+        "alias": alias,
+        "classification_notes": None,
+        "strategy": strategy,
+        "primary_key": ["id"],
+        "timestamp": None,
+        "grain": None,
+        "scd": None,
+        "mapping": None,
+        "dq_policy": None,
+        "load_contract": None,
+        "reason": "test",
+    }
+
+
+class TestLoadConfigWithCuration:
+    def test_loads_tables_from_curation_json(self, tmp_path: Path):
+        """When curation.json exists, tables come from it."""
+        from feather_etl.config import load_config
+
+        # Create a DuckDB source file
+        src_db = tmp_path / "source.duckdb"
+        con = duckdb.connect(str(src_db))
+        con.execute("CREATE SCHEMA erp")
+        con.execute("CREATE TABLE erp.orders (id INT, amount DOUBLE)")
+        con.execute("INSERT INTO erp.orders VALUES (1, 100.0)")
+        con.close()
+
+        config_file = _write_feather_yaml(tmp_path, [
+            {"type": "duckdb", "name": "erp", "path": str(src_db)},
+        ])
+        _write_curation(tmp_path, [
+            _make_include("erp", "erp.orders", "orders"),
+        ])
+
+        cfg = load_config(config_file, validate=False)
+        assert len(cfg.tables) == 1
+        assert cfg.tables[0].name == "erp_orders"
+        assert cfg.tables[0].target_table == "bronze.erp_orders"
+        assert cfg.tables[0].source_table == "erp.orders"
+        assert cfg.tables[0].database == "erp"
+
+    def test_multi_source_loads_from_curation(self, tmp_path: Path):
+        """Two sources, curation entries from each, all resolve."""
+        from feather_etl.config import load_config
+
+        # Create two DuckDB source files
+        src_a = tmp_path / "source_a.duckdb"
+        con = duckdb.connect(str(src_a))
+        con.execute("CREATE SCHEMA main")
+        con.execute("CREATE TABLE main.items (id INT)")
+        con.close()
+
+        src_b = tmp_path / "source_b.duckdb"
+        con = duckdb.connect(str(src_b))
+        con.execute("CREATE SCHEMA main")
+        con.execute("CREATE TABLE main.users (id INT)")
+        con.close()
+
+        config_file = _write_feather_yaml(tmp_path, [
+            {"type": "duckdb", "name": "inventory", "path": str(src_a)},
+            {"type": "duckdb", "name": "crm", "path": str(src_b)},
+        ])
+        _write_curation(tmp_path, [
+            _make_include("inventory", "main.items", "items"),
+            _make_include("crm", "main.users", "users"),
+        ])
+
+        cfg = load_config(config_file, validate=False)
+        assert len(cfg.tables) == 2
+        names = {t.name for t in cfg.tables}
+        assert names == {"inventory_items", "crm_users"}
+
+    def test_no_curation_no_tables_raises(self, tmp_path: Path):
+        """When neither curation.json nor tables: exists, error."""
+        from feather_etl.config import load_config
+
+        src_db = tmp_path / "source.duckdb"
+        src_db.touch()
+        config_file = _write_feather_yaml(tmp_path, [
+            {"type": "duckdb", "name": "erp", "path": str(src_db)},
+        ])
+
+        with pytest.raises(FileNotFoundError, match="curation.json"):
+            load_config(config_file, validate=False)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_curation_config_integration.py -v`
+Expected: FAIL — load_config still expects tables: in YAML
+
+- [ ] **Step 3: Modify load_config to use curation loader**
+
+In `src/feather_etl/config.py`, update `load_config()`:
+
+1. Remove `_parse_tables` and `_merge_tables_dir` calls (lines 374–376).
+2. Replace with curation loader import and call:
+
+```python
+from feather_etl.curation import load_curation_tables
+
+# ... after sources and destination are parsed ...
+
+# Tables come from curation.json
+tables = load_curation_tables(config_dir)
+```
+
+3. Remove the `if "tables" not in raw` check — tables no longer come from YAML.
+
+4. Update `_validate()` — remove the `primary.validate_source_table()` check that uses `config.sources[0]` (line 249). Source-table validation for curation entries will be handled by the curation validator (#29).
+
+- [ ] **Step 4: Run the integration tests**
+
+Run: `uv run pytest tests/test_curation_config_integration.py -v`
+Expected: All PASS
+
+- [ ] **Step 5: Run the full test suite, fix broken tests**
+
+Run: `uv run pytest -q`
+
+Many existing tests will fail because they use `tables:` in their YAML configs. These tests need a `discovery/curation.json` fixture instead. Update test helpers:
+
+In `tests/helpers.py`, add a function:
+
+```python
+import json
+
+
+def write_curation(tmp_path: Path, tables: list[dict]) -> Path:
+    """Write a discovery/curation.json for testing."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test fixture",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    path = discovery_dir / "curation.json"
+    path.write_text(json.dumps(manifest))
+    return path
+```
+
+Update existing test fixtures across `test_config.py`, `test_pipeline.py`, `test_e2e.py`, `test_mode.py`, and others to use `write_curation()` alongside `write_config()`. Each test that currently puts `tables:` in feather.yaml needs to instead write a curation.json with equivalent entries.
+
+This is the largest step — work through test files one at a time until `uv run pytest -q` passes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/feather_etl/config.py tests/helpers.py tests/test_curation_config_integration.py
+git add tests/  # all updated test files
+git commit -m "feat: wire curation.json as sole table manifest in load_config (#8, #15)"
+```
+
+---
+
+### Task 5: Update `run_table()` to accept source as parameter
+
+**Files:**
+- Modify: `src/feather_etl/pipeline.py:168-209` and `518-546`
+
+- [ ] **Step 1: Write the test**
+
+In `tests/test_pipeline.py`, add (or update existing test) to confirm source is passed through:
+
+```python
+def test_run_table_uses_provided_source(self, tmp_path: Path):
+    """run_table extracts from the source passed as argument, not sources[0]."""
+    # Setup: create a config with one source, but pass a different source to run_table
+    # The test confirms the passed source is used for extract, not config.sources[0]
+    from feather_etl.pipeline import run_table
+    from feather_etl.config import FeatherConfig, TableConfig, DestinationConfig, DefaultsConfig
+
+    # Create a real DuckDB source with data
+    import duckdb
+    src_path = tmp_path / "real_source.duckdb"
+    con = duckdb.connect(str(src_path))
+    con.execute("CREATE SCHEMA erp; CREATE TABLE erp.orders (id INT); INSERT INTO erp.orders VALUES (1), (2)")
+    con.close()
+
+    from feather_etl.sources.duckdb_file import DuckDBFileSource
+    real_source = DuckDBFileSource(path=src_path, name="real")
+
+    table = TableConfig(
+        name="erp_orders",
+        source_table="erp.orders",
+        strategy="full",
+        target_table="bronze.erp_orders",
+        primary_key=["id"],
+        source_name="real",
+        database="real",
+    )
+
+    config = FeatherConfig(
+        sources=[real_source],
+        destination=DestinationConfig(path=tmp_path / "dest.duckdb"),
+        tables=[table],
+        config_dir=tmp_path,
+    )
+
+    result = run_table(config, table, tmp_path, source=real_source)
+    assert result.status == "success"
+    assert result.rows_loaded == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_pipeline.py::test_run_table_uses_provided_source -v`
+Expected: FAIL — `run_table() got an unexpected keyword argument 'source'`
+
+- [ ] **Step 3: Update run_table signature**
+
+In `src/feather_etl/pipeline.py`, change `run_table`:
+
+```python
+def run_table(
+    config: FeatherConfig,
+    table: TableConfig,
+    working_dir: Path,
+    source: object | None = None,
+) -> RunResult:
+```
+
+Replace line 208 (`source = config.sources[0]`) with:
+
+```python
+    if source is None:
+        source = config.sources[0]
+```
+
+- [ ] **Step 4: Update `run_all()` to pass source per table**
+
+In `run_all()` (line 544), update the loop to resolve and pass the source:
+
+```python
+    from feather_etl.curation import resolve_source
+
+    results: list[RunResult] = []
+    for table in tables:
+        table_source = resolve_source(table.database, config.sources) if table.database else config.sources[0]
+        result = run_table(config, table, working_dir, source=table_source)
+        results.append(result)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `uv run pytest tests/test_pipeline.py -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/feather_etl/pipeline.py tests/test_pipeline.py
+git commit -m "feat: run_table accepts source param, run_all resolves per table (#8)"
+```
+
+---
+
+### Task 6: Remove `_enforce_single_source` from all commands
+
+**Files:**
+- Modify: `src/feather_etl/commands/_common.py:19-28`
+- Modify: `src/feather_etl/commands/run.py:10,27`
+- Modify: `src/feather_etl/commands/setup.py:10,27`
+- Modify: `src/feather_etl/commands/status.py:10,24`
+- Modify: `src/feather_etl/commands/validate.py:10,22`
+- Modify: `src/feather_etl/commands/history.py:10,27`
+
+- [ ] **Step 1: Delete `_enforce_single_source` from _common.py**
+
+In `src/feather_etl/commands/_common.py`, delete lines 19–28 (the entire function).
+
+- [ ] **Step 2: Remove import and call from each command**
+
+In each of these files, remove `_enforce_single_source` from the import and delete the call line:
+
+- `commands/run.py`: remove from import (line 10), delete call (line 27)
+- `commands/setup.py`: remove from import (line 10), delete call (line 27)
+- `commands/status.py`: remove from import (line 10), delete call (line 24)
+- `commands/validate.py`: remove from import (line 10), delete call (line 22)
+- `commands/history.py`: remove from import (line 10), delete call (line 27)
+
+- [ ] **Step 3: Update validate command for multi-source**
+
+In `commands/validate.py`, update the source check section (lines 24–58) to iterate all sources:
+
+```python
+    # Test source connections
+    all_ok = True
+    for source in cfg.sources:
+        source_ok = source.check()
+        if not source_ok:
+            all_ok = False
+        if not _is_json(ctx):
+            source_label = (
+                getattr(source, "path", None)
+                or getattr(source, "host", None)
+                or "configured"
+            )
+            conn_status = "connected" if source_ok else "FAILED"
+            typer.echo(f"  Source: {source.type} ({source_label}) — {conn_status}")
+            if not source_ok:
+                err = getattr(source, "_last_error", None)
+                if err:
+                    typer.echo(f"    Details: {err}", err=True)
+
+    if not all_ok:
+        raise typer.Exit(code=2)
+```
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: All tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feather_etl/commands/_common.py src/feather_etl/commands/run.py \
+  src/feather_etl/commands/setup.py src/feather_etl/commands/status.py \
+  src/feather_etl/commands/validate.py src/feather_etl/commands/history.py
+git commit -m "feat: remove _enforce_single_source gate from all commands (#8)"
+```
+
+---
+
+### Task 7: End-to-end multi-source extraction test
+
+**Files:**
+- Create: `tests/test_multi_source_e2e.py`
+
+- [ ] **Step 1: Write the e2e test**
+
+Create `tests/test_multi_source_e2e.py`:
+
+```python
+"""End-to-end test: multi-source extraction via curation.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+import yaml
+
+from feather_etl.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _setup_multi_source_project(tmp_path: Path) -> Path:
+    """Create a project with 2 DuckDB sources + curation.json."""
+    # Source A: ERP with orders and customers
+    src_a = tmp_path / "erp.duckdb"
+    con = duckdb.connect(str(src_a))
+    con.execute("CREATE SCHEMA erp")
+    con.execute("CREATE TABLE erp.orders (id INT, amount DOUBLE)")
+    con.execute("INSERT INTO erp.orders VALUES (1, 100.0), (2, 200.0), (3, 300.0)")
+    con.execute("CREATE TABLE erp.customers (id INT, name VARCHAR)")
+    con.execute("INSERT INTO erp.customers VALUES (1, 'Alice'), (2, 'Bob')")
+    con.close()
+
+    # Source B: SQLite-like DuckDB with products
+    src_b = tmp_path / "inventory.duckdb"
+    con = duckdb.connect(str(src_b))
+    con.execute("CREATE SCHEMA inv")
+    con.execute("CREATE TABLE inv.products (id INT, sku VARCHAR, price DOUBLE)")
+    con.execute("INSERT INTO inv.products VALUES (1, 'SKU001', 9.99), (2, 'SKU002', 19.99)")
+    con.close()
+
+    # feather.yaml — two sources, no tables
+    config = {
+        "sources": [
+            {"type": "duckdb", "name": "erp", "path": str(src_a)},
+            {"type": "duckdb", "name": "inventory", "path": str(src_b)},
+        ],
+        "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+    }
+    config_file = tmp_path / "feather.yaml"
+    config_file.write_text(yaml.dump(config, default_flow_style=False))
+
+    # discovery/curation.json — 3 include entries across 2 sources
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir()
+    curation = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": [
+            {
+                "source_db": "erp",
+                "source_table": "erp.orders",
+                "decision": "include",
+                "table_type": "fact",
+                "group": "erp",
+                "alias": "orders",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": "one row per order",
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "erp",
+                "source_table": "erp.customers",
+                "decision": "include",
+                "table_type": "dimension",
+                "group": "erp",
+                "alias": "customers",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "inventory",
+                "source_table": "inv.products",
+                "decision": "include",
+                "table_type": "dimension",
+                "group": "inventory",
+                "alias": "products",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "erp",
+                "source_table": "erp.audit_log",
+                "decision": "exclude",
+                "table_type": "audit",
+                "group": "erp",
+                "alias": None,
+                "classification_notes": None,
+                "strategy": None,
+                "primary_key": None,
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "not needed",
+            },
+        ],
+    }
+    (discovery_dir / "curation.json").write_text(json.dumps(curation))
+
+    return config_file
+
+
+class TestMultiSourceE2E:
+    def test_feather_run_extracts_from_multiple_sources(self, tmp_path: Path, monkeypatch):
+        """feather run extracts tables from 2 DuckDB sources via curation.json."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+
+        result = runner.invoke(app, ["run", "--config", str(config_file)])
+        assert result.exit_code == 0, f"stdout: {result.stdout}\nstderr: {result.stderr if hasattr(result, 'stderr') else ''}"
+
+        # Verify data landed in bronze
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        tables = [
+            row[0]
+            for row in dest.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
+            ).fetchall()
+        ]
+        dest.close()
+
+        assert "erp_orders" in tables
+        assert "erp_customers" in tables
+        assert "inventory_products" in tables
+        assert len(tables) == 3  # excluded table not present
+
+    def test_row_counts_correct(self, tmp_path: Path, monkeypatch):
+        """Verify row counts match source data."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+        runner.invoke(app, ["run", "--config", str(config_file)])
+
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        orders = dest.execute("SELECT COUNT(*) FROM bronze.erp_orders").fetchone()[0]
+        customers = dest.execute("SELECT COUNT(*) FROM bronze.erp_customers").fetchone()[0]
+        products = dest.execute("SELECT COUNT(*) FROM bronze.inventory_products").fetchone()[0]
+        dest.close()
+
+        assert orders == 3
+        assert customers == 2
+        assert products == 2
+
+    def test_table_filter_works_with_bronze_name(self, tmp_path: Path, monkeypatch):
+        """--table flag filters by curation-derived bronze name."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+
+        result = runner.invoke(app, ["run", "--config", str(config_file), "--table", "erp_orders"])
+        assert result.exit_code == 0
+
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        tables = [
+            row[0]
+            for row in dest.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
+            ).fetchall()
+        ]
+        dest.close()
+
+        assert "erp_orders" in tables
+        assert "erp_customers" not in tables  # not extracted — filtered out
+```
+
+- [ ] **Step 2: Run e2e tests**
+
+Run: `uv run pytest tests/test_multi_source_e2e.py -v`
+Expected: All 3 tests PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: All tests pass
+
+- [ ] **Step 4: Run ruff format**
+
+Run: `ruff format .`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_multi_source_e2e.py
+git commit -m "test: add multi-source e2e extraction tests (#8, #15)"
+```
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-multi-source-pipeline.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-04-18-multi-source-pipeline.md
+++ b/docs/superpowers/plans/2026-04-18-multi-source-pipeline.md
@@ -395,6 +395,30 @@ class TestLoadCuration:
         # Should be lowercased and sanitized
         assert result[0].name == "my_source_sales_data_"
 
+    def test_bronze_name_collision_case_difference_raises(self, tmp_path: Path):
+        """Two aliases that differ only in case must collide after normalization."""
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(source_db="SAP", alias="Sales"),
+            _make_include_entry(source_db="SAP", alias="sales"),
+        ]
+        _write_curation(tmp_path, tables)
+        with pytest.raises(ValueError, match="duplicate bronze.*sap_sales"):
+            load_curation_tables(tmp_path)
+
+    def test_bronze_name_collision_punctuation_difference_raises(self, tmp_path: Path):
+        """Two aliases that differ only in punctuation must collide after normalization."""
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(source_db="SAP", alias="sales_b"),
+            _make_include_entry(source_db="SAP", alias="sales-b"),
+        ]
+        _write_curation(tmp_path, tables)
+        with pytest.raises(ValueError, match="duplicate bronze.*sap_sales_b"):
+            load_curation_tables(tmp_path)
+
 
 class TestResolveSource:
     def test_resolves_source_by_databases_list(self):
@@ -554,10 +578,21 @@ def load_curation_tables(config_dir: Path) -> list[TableConfig]:
         )
 
     tables: list[TableConfig] = []
+    seen_bronze_names: dict[str, str] = {}  # bronze_name -> "source_db.alias"
     for entry in includes:
         source_db = entry["source_db"]
         alias = entry.get("alias") or entry["source_table"].split(".")[-1]
         bronze_name = _sanitize_bronze_name(source_db, alias)
+
+        # Collision check on normalized bronze name
+        origin = f"{source_db}.{alias}"
+        if bronze_name in seen_bronze_names:
+            raise ValueError(
+                f"duplicate bronze target name '{bronze_name}' — "
+                f"entries {seen_bronze_names[bronze_name]} and {origin} "
+                f"normalize to the same identifier. Use distinct aliases."
+            )
+        seen_bronze_names[bronze_name] = origin
 
         timestamp_column = None
         ts = entry.get("timestamp")
@@ -759,7 +794,7 @@ tables = load_curation_tables(config_dir)
 
 3. Remove the `if "tables" not in raw` check — tables no longer come from YAML.
 
-4. Update `_validate()` — remove the `primary.validate_source_table()` check that uses `config.sources[0]` (line 249). Source-table validation for curation entries will be handled by the curation validator (#29).
+4. Update `_validate()` — keep `validate_source_table()` checks but run them per-table against the resolved source instead of hardcoding `config.sources[0]`. For each table, resolve its source via `resolve_source(table.database, config.sources)` and call `source.validate_source_table(table.source_table)`. This preserves the existing safety fence that prevents malformed or hostile table names from reaching query construction (e.g., SQLite's `sqlite_scan(..., '{table}')`).
 
 - [ ] **Step 4: Run the integration tests**
 

--- a/docs/superpowers/specs/2026-04-18-multi-source-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-18-multi-source-pipeline-design.md
@@ -1,0 +1,193 @@
+# Multi-source pipeline + curation-driven extraction — design
+
+**Issues:** [#8 Support multiple sources per project](https://github.com/siraj-samsudeen/feather-etl/issues/8), [#15 Introduce feather snapshot](https://github.com/siraj-samsudeen/feather-etl/issues/15)
+**Depends on:** [#29 Curation manifest schema v2](https://github.com/siraj-samsudeen/feather-etl/issues/29) (validator being built in parallel — pipeline validation rules posted as comment)
+**Closes:** #27 (DatabaseSource isinstance refactor)
+**Status:** Design approved, ready for implementation planning
+**Date:** 2026-04-18
+
+---
+
+## 1. Problem
+
+The config layer already supports `sources:` (list) and `feather discover` handles multi-source + multi-database expansion. But the pipeline (`feather run`) and all other non-discover commands are hard-gated to single-source:
+
+- `_enforce_single_source()` in `_common.py` exits with code 2 for multi-source configs.
+- `pipeline.py:run_table()` hardcodes `source = config.sources[0]`.
+- `TableConfig` has no field to route a table to its source.
+
+Separately, the `tables:` section in `feather.yaml` requires manual specification of every table to extract. The `discovery/curation.json` manifest (already in use in client projects) captures table selection decisions with richer metadata — strategy, primary key, timestamp, alias, table type — making the YAML `tables:` section redundant.
+
+---
+
+## 2. Scope
+
+**In:**
+- Pipeline gains multi-source routing — each table extracts from the correct source.
+- `curation.json` replaces `tables:` as the table manifest for `feather run`.
+- Source resolution: `source_db` in curation entries resolves against `sources:` in `feather.yaml`.
+- Bronze target naming derived from `source_db` + `alias`.
+- `_enforce_single_source` gate removed from all commands.
+- `_expand_db_sources` extracted to shared utility using `DatabaseSource` base class (closes #27).
+
+**Out:**
+- Bronze file strategy / configurable file splitting (#31).
+- Configurable layer architecture (#30).
+- Silver/gold generation, SCD, mapping table handling (#32, #33, #34, #35).
+- Curation manifest JSON Schema validator (#29 — built in parallel).
+- Change preview / confirmation UX (deferred to a follow-up on #15).
+
+---
+
+## 3. Summary of decisions
+
+| Area | Decision | Rationale |
+|------|----------|-----------|
+| Table manifest | `discovery/curation.json` is the sole table source. `tables:` section in feather.yaml removed. | Tables come from discover → curate workflow. Manual YAML tables was interim. |
+| Source reference | Each curation entry has `source_db` which resolves against feather.yaml sources' `database:` / `databases:` fields. | Users reference what they declared in `sources:`. Internal naming (`Rama__Gofrugal`) stays internal. |
+| Database reference | Explicit `source_db` field in curation.json, not encoded in `source_table`. | Unambiguous. Avoids misparse when schema name looks like a database name. |
+| Bronze target naming | `bronze.<source_db>_<alias>` (lowercased, sanitized). | `alias` is human-curated in curation.json. Prefixing with `source_db` prevents collisions across sources. |
+| Source resolution | Done in config layer at parse time. | Fail-fast: typos caught before extraction starts. Single validation path for all commands. |
+| Backward compat | No fallback to `tables:` section. If `curation.json` missing → error with guidance to run `feather discover`. | Clean cut. Dual-path logic adds complexity for a transition that should be one-time. |
+| DuckDB layout | Single DuckDB file, single `bronze` schema. | Cross-source JOINs stay trivial. Configurable splitting deferred to #31. |
+| `_expand_db_sources` | Extracted to `src/feather_etl/sources/expand.py`, uses `DatabaseSource` base class. | Shared between discover and pipeline. Closes #27. |
+
+---
+
+## 4. User-facing contract
+
+### feather.yaml (simplified)
+
+```yaml
+sources:
+  - name: Rama
+    type: sqlserver
+    host: ${SQLSERVER_HOST}
+    databases: [Gofrugal, Portal, SAP, ZAKYA]
+
+  - name: RamaMySQL
+    type: mysql
+    host: ${MYSQL_HOST}
+    databases: [allinc_stg, allsrc_stg, allzak_stg, core_db]
+
+destination:
+  path: ./feather_data.duckdb
+
+# No tables: section — tables come from discovery/curation.json
+```
+
+### discovery/curation.json (v2 — table manifest)
+
+Each entry with `decision: "include"` is extracted. Fields consumed by the pipeline:
+
+| Field | Pipeline use |
+|---|---|
+| `source_db` | Resolves to the correct source + database |
+| `source_table` | Passed to `source.extract()` |
+| `decision` | Only `"include"` entries are extracted |
+| `strategy` | `full`, `incremental`, or `append` |
+| `primary_key` | Passed to pipeline for dedup / boundary detection |
+| `timestamp.column` | Watermark column for incremental extraction |
+| `alias` | Used to derive bronze target: `bronze.<source_db>_<alias>` |
+
+All other v2 fields (`table_type`, `grain`, `scd`, `mapping`, `load_contract`, `dq_policy`) are parsed but not consumed by the bronze pipeline — they are reserved for future silver/gold generators.
+
+### Source resolution rules
+
+| Scenario | Behavior |
+|---|---|
+| `source_db` matches a source's `database:` field | Use that source |
+| `source_db` is in a source's `databases:` list | Create a scoped source instance with that database |
+| `source_db` matches no source | Validation error |
+| `source_db` matches multiple sources | Validation error (ambiguous) |
+| File sources (no `database` concept) | `source_db` matches the source `name` directly (e.g., source named `"erp"` with `type: duckdb` → curation uses `source_db: "erp"`) |
+
+### CLI
+
+No new commands. Existing commands work unchanged:
+
+- `uv run feather run` — extracts all `include` tables from curation.json across all sources
+- `uv run feather run --table gofrugal_sales` — extract single table by bronze name
+- `uv run feather status`, `uv run feather setup` — gate removed, work with multi-source
+
+---
+
+## 5. Integration surface
+
+### Files that change
+
+| File | Change | Risk |
+|---|---|---|
+| `config.py` | Add curation.json loader. `TableConfig` gains `source` + `database` fields. Source resolution logic. Remove `tables:` parsing. | Medium — core change |
+| `pipeline.py` | `run_table()` accepts source as parameter instead of `sources[0]`. | Low — mechanical |
+| `commands/_common.py` | Remove `_enforce_single_source()`. | Low — deleting code |
+| `commands/run.py` | Remove gate call. Adapt table filter for curation-derived names. | Low |
+| `commands/setup.py`, `status.py` | Remove gate call. | Low |
+| `commands/discover.py` | Extract `_expand_db_sources` to shared utility. | Low — moving code |
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `curation.py` | Load `discovery/curation.json`, filter to `include`, resolve `source_db` → source, produce `TableConfig` list. |
+| `sources/expand.py` | Shared `_expand_db_sources` using `DatabaseSource` base class. Used by discover and pipeline. |
+
+---
+
+## 6. Task breakdown
+
+| # | Task | Why / Risk |
+|---|---|---|
+| 1 | Extract `_expand_db_sources` to shared utility, use `DatabaseSource` base class | Prerequisite for pipeline source scoping. Closes #27. |
+| 2 | Add `source` and `database` fields to `TableConfig` | Pipeline needs to know which source each table belongs to. Additive, backward-safe. |
+| 3 | Build curation.json loader (`curation.py`) | Core new module. Parses manifest, filters to include, resolves source_db, produces TableConfig list. |
+| 4 | Wire curation loader into `load_config()` | Config layer reads curation.json as the sole table source. Remove `tables:` parsing. |
+| 5 | Update `run_table()` to accept source as parameter | Remove `sources[0]` hardcode. |
+| 6 | Remove `_enforce_single_source` from all commands | Unlocks multi-source for run, setup, status. |
+| 7 | End-to-end tests with file-based multi-source | Prove multi-source extraction works using DuckDB + SQLite + CSV as sources. No database server dependencies (requires client VPN). |
+
+### Dependency chain
+
+```
+Task 1 (expand utility) ──┐
+Task 2 (TableConfig fields) ──┼──→ Task 3 (curation loader) ──→ Task 4 (wire into load_config)
+                               │
+                               └──→ Task 5 (run_table param) ──→ Task 6 (remove gates)
+                                                                          │
+                                                                  Task 7 (e2e tests)
+```
+
+Tasks 1 and 2 are independent (parallel). Task 3 depends on both. Tasks 5 and 6 can start after Task 2. Task 7 validates the full integration.
+
+---
+
+## 7. Done signal
+
+```bash
+# From a test project directory with:
+#   feather.yaml — 2+ file-based sources (e.g., DuckDB + SQLite + CSV), no tables: section
+#   discovery/curation.json — include entries across multiple source_dbs
+
+uv run feather run
+
+# Output shows tables extracted from different file sources into bronze:
+#   erp_orders: success (12 rows)
+#   erp_customers: success (5 rows)
+#   csvdata_products: success (10 rows)
+
+uv run pytest -q   # all tests pass
+```
+
+---
+
+## 8. Related issues
+
+| Issue | Relationship |
+|---|---|
+| #8 | Core of this design — multi-source pipeline routing |
+| #15 | Curation-driven extraction (snapshot) |
+| #27 | Closed by Task 1 — DatabaseSource isinstance refactor |
+| #29 | Parallel — validator enforces rules pipeline depends on (comment posted) |
+| #31 | Future — bronze file strategy builds on this foundation |
+| #30 | Future — layer architecture builds on this foundation |
+| #18 | Naturally addressed — curation entries target bronze only |

--- a/docs/superpowers/specs/2026-04-18-multi-source-pipeline-design.md
+++ b/docs/superpowers/specs/2026-04-18-multi-source-pipeline-design.md
@@ -140,8 +140,8 @@ No new commands. Existing commands work unchanged:
 |---|---|---|
 | 1 | Extract `_expand_db_sources` to shared utility, use `DatabaseSource` base class | Prerequisite for pipeline source scoping. Closes #27. |
 | 2 | Add `source` and `database` fields to `TableConfig` | Pipeline needs to know which source each table belongs to. Additive, backward-safe. |
-| 3 | Build curation.json loader (`curation.py`) | Core new module. Parses manifest, filters to include, resolves source_db, produces TableConfig list. |
-| 4 | Wire curation loader into `load_config()` | Config layer reads curation.json as the sole table source. Remove `tables:` parsing. |
+| 3 | Build curation.json loader (`curation.py`) | Core new module. Parses manifest, filters to include, resolves source_db, produces TableConfig list. Detects bronze name collisions after normalization (case/punctuation differences that map to the same identifier). |
+| 4 | Wire curation loader into `load_config()` | Config layer reads curation.json as the sole table source. Remove `tables:` parsing. Keep `validate_source_table()` — run per-table against resolved source to prevent malformed table names reaching query construction. |
 | 5 | Update `run_table()` to accept source as parameter | Remove `sources[0]` hardcode. |
 | 6 | Remove `_enforce_single_source` from all commands | Unlocks multi-source for run, setup, status. |
 | 7 | End-to-end tests with file-based multi-source | Prove multi-source extraction works using DuckDB + SQLite + CSV as sources. No database server dependencies (requires client VPN). |

--- a/src/feather_etl/commands/_common.py
+++ b/src/feather_etl/commands/_common.py
@@ -28,12 +28,24 @@ def _enforce_single_source(cfg: FeatherConfig, command_name: str) -> None:
         raise typer.Exit(code=2)
 
 
-def _load_and_validate(config_path: Path, mode_override: str | None = None):
-    """Load config, validate, write validation JSON. Raises on failure."""
+def _load_and_validate(
+    config_path: Path,
+    mode_override: str | None = None,
+    discover_mode: bool = False,
+):
+    """Load config, validate, write validation JSON. Raises on failure.
+
+    When *discover_mode* is True the loader skips table validation because
+    ``feather discover`` runs **before** curation.json exists.
+    """
     from feather_etl.config import load_config, write_validation_json
 
     try:
-        cfg = load_config(config_path, mode_override=mode_override)
+        cfg = load_config(
+            config_path,
+            mode_override=mode_override,
+            validate=not discover_mode,
+        )
         write_validation_json(config_path, cfg)
         return cfg
     except (ValueError, FileNotFoundError) as e:

--- a/src/feather_etl/commands/_common.py
+++ b/src/feather_etl/commands/_common.py
@@ -16,18 +16,6 @@ def _is_json(ctx: typer.Context) -> bool:
     return ctx.ensure_object(dict).get("json_mode", False)
 
 
-def _enforce_single_source(cfg: FeatherConfig, command_name: str) -> None:
-    """Exit 2 if cfg has multiple sources. Used by every non-discover command."""
-    if len(cfg.sources) > 1:
-        typer.echo(
-            f"Command '{command_name}' is single-source for now (multi-source support is tracked in issue #8). "
-            f"Use `feather discover` to enumerate multi-source schemas, or "
-            f"split into one feather.yaml per source for non-discover operations.",
-            err=True,
-        )
-        raise typer.Exit(code=2)
-
-
 def _load_and_validate(
     config_path: Path,
     mode_override: str | None = None,

--- a/src/feather_etl/commands/discover.py
+++ b/src/feather_etl/commands/discover.py
@@ -70,7 +70,7 @@ def discover(
     ),
 ) -> None:
     """Save each source's schema to an auto-named schema JSON file, then serve/open the schema viewer."""
-    cfg = _load_and_validate(config)
+    cfg = _load_and_validate(config, discover_mode=True)
     target_dir = Path(".")
     state = DiscoverState.load(target_dir)
 

--- a/src/feather_etl/commands/discover.py
+++ b/src/feather_etl/commands/discover.py
@@ -16,6 +16,7 @@ from feather_etl.discover_state import (
     classify,
     detect_renames,
 )
+from feather_etl.sources.expand import expand_db_sources
 from feather_etl.viewer_server import serve_and_open
 
 
@@ -32,69 +33,6 @@ def _write_schema(source, target_dir: Path) -> tuple[Path, int]:
     out = target_dir / schema_output_path(source)
     out.write_text(json.dumps(payload, indent=2))
     return out, len(schemas)
-
-
-def _expand_db_sources(sources: list) -> list:
-    """Expand sqlserver/postgres sources without explicit database into child sources.
-
-    For each parent source:
-      - If it has `database` set → keep as-is.
-      - If it has `databases: [...]` set → produce one child per entry, named
-        `<parent_name>__<db>`, with `database` set on the child.
-      - Otherwise (DB source, neither set) → call list_databases() and
-        produce one child per result.
-      - File sources → keep as-is.
-    """
-    from feather_etl.sources.mysql import MySQLSource
-    from feather_etl.sources.postgres import PostgresSource
-    from feather_etl.sources.sqlserver import SqlServerSource
-
-    expanded: list = []
-    for src in sources:
-        is_db = isinstance(src, (SqlServerSource, PostgresSource, MySQLSource))
-        if not is_db:
-            expanded.append(src)
-            continue
-        if src.database is not None:
-            expanded.append(src)
-            continue
-        databases = src.databases
-        if databases is None:
-            try:
-                databases = src.list_databases()
-            except Exception as e:
-                src._last_error = (
-                    f"Found 0 databases on host {src.host}. Either grant "
-                    f"VIEW ANY DATABASE to this login, or specify "
-                    f"`database:` / `databases: [...]` explicitly. ({e})"
-                )
-                expanded.append(src)
-                continue
-            if not databases:
-                src._last_error = (
-                    f"Found 0 databases on host {src.host}. Either grant "
-                    f"VIEW ANY DATABASE to this login, or specify "
-                    f"`database:` / `databases: [...]` explicitly."
-                )
-                expanded.append(src)
-                continue
-        # DB sources' from_yaml ignores config_dir (it's only used for file-path resolution)
-        for db in databases:
-            child = type(src).from_yaml(
-                {
-                    "name": f"{src.name}__{db}",
-                    "type": src.type,
-                    "host": src.host,
-                    "port": src.port,
-                    "user": src.user,
-                    "password": src.password,
-                    "database": db,
-                },
-                Path("."),
-            )
-            child._explicit_name = getattr(src, "_explicit_name", False)
-            expanded.append(child)
-    return expanded
 
 
 def _fingerprint_for(source) -> str:
@@ -136,7 +74,7 @@ def discover(
     target_dir = Path(".")
     state = DiscoverState.load(target_dir)
 
-    sources = _expand_db_sources(cfg.sources)
+    sources = expand_db_sources(cfg.sources)
     flag: str | None = None
     if refresh:
         flag = "refresh"
@@ -256,7 +194,7 @@ def discover(
             typer.echo(f"{prefix}  (skipped)")
             continue
 
-        # Source came from _expand_db_sources with a pre-set error (e.g. empty enumeration).
+        # Source came from expand_db_sources with a pre-set error (e.g. empty enumeration).
         if hasattr(source, "_last_error") and source._last_error:
             failed_count += 1
             state.record_failed(

--- a/src/feather_etl/commands/history.py
+++ b/src/feather_etl/commands/history.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 
 from feather_etl.commands._common import (
-    _enforce_single_source,
     _is_json,
     _load_and_validate,
 )
@@ -24,7 +23,6 @@ def history(
     from feather_etl.state import StateManager
 
     cfg = _load_and_validate(config)
-    _enforce_single_source(cfg, "history")
     state_path = cfg.config_dir / "feather_state.duckdb"
 
     if not state_path.exists():

--- a/src/feather_etl/commands/run.py
+++ b/src/feather_etl/commands/run.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 
 from feather_etl.commands._common import (
-    _enforce_single_source,
     _is_json,
     _load_and_validate,
 )
@@ -24,7 +23,6 @@ def run(
     from feather_etl.pipeline import run_all
 
     cfg = _load_and_validate(config, mode_override=mode)
-    _enforce_single_source(cfg, "run")
     if not _is_json(ctx):
         typer.echo(f"Mode: {cfg.mode}")
     try:

--- a/src/feather_etl/commands/setup.py
+++ b/src/feather_etl/commands/setup.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 
 from feather_etl.commands._common import (
-    _enforce_single_source,
     _is_json,
     _load_and_validate,
 )
@@ -24,7 +23,6 @@ def setup(
     from feather_etl.state import StateManager
 
     cfg = _load_and_validate(config, mode_override=mode)
-    _enforce_single_source(cfg, "setup")
     if not _is_json(ctx):
         typer.echo(f"Mode: {cfg.mode}")
 

--- a/src/feather_etl/commands/status.py
+++ b/src/feather_etl/commands/status.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 
 from feather_etl.commands._common import (
-    _enforce_single_source,
     _is_json,
     _load_and_validate,
 )
@@ -21,7 +20,6 @@ def status(
     from feather_etl.state import StateManager
 
     cfg = _load_and_validate(config)
-    _enforce_single_source(cfg, "status")
     state_path = cfg.config_dir / "feather_state.duckdb"
 
     if not state_path.exists():

--- a/src/feather_etl/commands/validate.py
+++ b/src/feather_etl/commands/validate.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import typer
 
 from feather_etl.commands._common import (
-    _enforce_single_source,
     _is_json,
     _load_and_validate,
 )
@@ -19,11 +18,25 @@ def validate(
 ) -> None:
     """Validate config, test source connection, and write feather_validation.json."""
     cfg = _load_and_validate(config)
-    _enforce_single_source(cfg, "validate")
 
-    # Test source connection
-    source = cfg.sources[0]
-    source_ok = source.check()
+    # Test source connections
+    all_ok = True
+    for source in cfg.sources:
+        source_ok = source.check()
+        if not source_ok:
+            all_ok = False
+        if not _is_json(ctx):
+            source_label = (
+                getattr(source, "path", None)
+                or getattr(source, "host", None)
+                or "configured"
+            )
+            conn_status = "connected" if source_ok else "FAILED"
+            typer.echo(f"  Source: {source.type} ({source_label}) — {conn_status}")
+            if not source_ok:
+                err = getattr(source, "_last_error", None)
+                if err:
+                    typer.echo(f"    Details: {err}", err=True)
 
     if _is_json(ctx):
         emit_line(
@@ -33,29 +46,19 @@ def validate(
                 "source_type": cfg.sources[0].type,
                 "destination": str(cfg.destination.path),
                 "mode": cfg.mode,
-                "source_connected": source_ok,
+                "source_connected": all_ok,
             },
             json_mode=True,
         )
     else:
         typer.echo(f"Config valid: {len(cfg.tables)} table(s)")
-        source_label = (
-            getattr(cfg.sources[0], "path", None)
-            or getattr(cfg.sources[0], "host", None)
-            or "configured"
-        )
-        conn_status = "connected" if source_ok else "FAILED"
-        typer.echo(f"  Source: {cfg.sources[0].type} ({source_label}) — {conn_status}")
         typer.echo(f"  Destination: {cfg.destination.path}")
         typer.echo(f"  State: {cfg.config_dir / 'feather_state.duckdb'}")
         for t in cfg.tables:
             typer.echo(f"  Table: {t.name} → {t.target_table} ({t.strategy})")
 
-    if not source_ok:
+    if not all_ok:
         typer.echo("Source connection failed.", err=True)
-        err = getattr(source, "_last_error", None)
-        if err:
-            typer.echo(f"  Details: {err}", err=True)
         raise typer.Exit(code=2)
 
 

--- a/src/feather_etl/config.py
+++ b/src/feather_etl/config.py
@@ -205,9 +205,8 @@ def _validate(config: FeatherConfig) -> list[str]:
             f"got {config.defaults.overlap_window_minutes}"
         )
 
-    # Use the primary (first) source for source_table validation until
-    # per-table routing lands in a later task.
-    primary = config.sources[0]
+    from feather_etl.curation import resolve_source
+
     for table in config.tables:
         if table.strategy not in VALID_STRATEGIES:
             errors.append(
@@ -247,8 +246,15 @@ def _validate(config: FeatherConfig) -> list[str]:
                 f"exclusive — use one or the other."
             )
 
-        # Source-type-aware source_table validation — delegated to the source class.
-        for err in primary.validate_source_table(table.source_table):
+        # Source-type-aware source_table validation — resolve per-table source.
+        try:
+            source = resolve_source(
+                table.database or table.source_name or "",
+                config.sources,
+            )
+        except ValueError:
+            source = config.sources[0]
+        for err in source.validate_source_table(table.source_table):
             errors.append(f"Table '{table.name}': {err}")
 
     return errors
@@ -373,9 +379,14 @@ def load_config(
             f"Invalid mode '{mode}' (from {mode_source}). Valid: {sorted(VALID_MODES)}"
         )
 
-    raw_tables = raw.get("tables", [])
-    raw_tables = _merge_tables_dir(config_dir, raw_tables)
-    tables = _parse_tables(raw_tables, raw)
+    from feather_etl.curation import load_curation_tables
+
+    try:
+        tables = load_curation_tables(config_dir)
+    except (FileNotFoundError, ValueError):
+        if validate:
+            raise
+        tables = []
 
     # Parse optional alerts section
     alerts: AlertsConfig | None = None

--- a/src/feather_etl/config.py
+++ b/src/feather_etl/config.py
@@ -97,6 +97,8 @@ class TableConfig:
     schedule: str | None = None
     dedup: bool = False
     dedup_columns: list[str] | None = None
+    source_name: str | None = None  # resolved source name from curation
+    database: str | None = None  # resolved database from curation
 
 
 @dataclass

--- a/src/feather_etl/curation.py
+++ b/src/feather_etl/curation.py
@@ -106,7 +106,7 @@ def load_curation_tables(config_dir: Path) -> list[TableConfig]:
                 name=bronze_name,
                 source_table=entry["source_table"],
                 strategy=entry["strategy"],
-                target_table=f"bronze.{bronze_name}",
+                target_table="",  # mode-derived at runtime by _resolve_target
                 primary_key=entry.get("primary_key"),
                 timestamp_column=timestamp_column,
                 source_name=source_db,

--- a/src/feather_etl/curation.py
+++ b/src/feather_etl/curation.py
@@ -1,0 +1,117 @@
+"""Curation manifest loader — reads discovery/curation.json as the table manifest."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from feather_etl.config import TableConfig
+
+_UNSAFE_CHARS = re.compile(r"[^a-z0-9_]")
+
+
+def _sanitize_bronze_name(source_db: str, alias: str) -> str:
+    """Derive a sanitized bronze table name from source_db and alias.
+
+    Format: <source_db>_<alias>, lowercased, non-alphanum replaced with underscore.
+    """
+    raw = f"{source_db}_{alias}".lower()
+    return _UNSAFE_CHARS.sub("_", raw)
+
+
+def resolve_source(source_db: str, sources: list) -> object:
+    """Find the source that owns the given database name.
+
+    Resolution order:
+    1. source.database == source_db (single-database source)
+    2. source_db in source.databases (multi-database source)
+    3. source.name == source_db (file sources — no database concept)
+
+    Raises ValueError if no match or ambiguous match.
+    """
+    matches = []
+    for src in sources:
+        db = getattr(src, "database", None)
+        dbs = getattr(src, "databases", None)
+        if db is not None and db == source_db:
+            matches.append(src)
+        elif dbs is not None and source_db in dbs:
+            matches.append(src)
+        elif src.name == source_db:
+            matches.append(src)
+
+    if len(matches) == 0:
+        available = ", ".join(s.name for s in sources)
+        raise ValueError(
+            f"source_db '{source_db}' does not match any declared source. "
+            f"Available sources: {available}"
+        )
+    if len(matches) > 1:
+        names = ", ".join(s.name for s in matches)
+        raise ValueError(
+            f"source_db '{source_db}' is ambiguous — matches multiple sources: {names}"
+        )
+    return matches[0]
+
+
+def load_curation_tables(config_dir: Path) -> list[TableConfig]:
+    """Load discovery/curation.json and produce TableConfig list from include entries.
+
+    Raises FileNotFoundError if curation.json does not exist.
+    Raises ValueError if no tables have decision 'include'.
+    Raises ValueError if two include entries normalize to the same bronze table name.
+    """
+    curation_path = config_dir / "discovery" / "curation.json"
+    if not curation_path.exists():
+        raise FileNotFoundError(
+            f"discovery/curation.json not found in {config_dir}. "
+            f"Run 'feather discover' and curate tables first."
+        )
+
+    manifest = json.loads(curation_path.read_text())
+    raw_tables = manifest.get("tables", [])
+    includes = [t for t in raw_tables if t.get("decision") == "include"]
+
+    if not includes:
+        raise ValueError(
+            "No tables with decision 'include' in discovery/curation.json. "
+            "Curate at least one table before running."
+        )
+
+    tables: list[TableConfig] = []
+    seen_bronze_names: dict[str, str] = {}  # bronze_name -> "source_db.alias"
+    for entry in includes:
+        source_db = entry["source_db"]
+        alias = entry.get("alias") or entry["source_table"].split(".")[-1]
+        bronze_name = _sanitize_bronze_name(source_db, alias)
+
+        # Collision check on normalized bronze name
+        origin = f"{source_db}.{alias}"
+        if bronze_name in seen_bronze_names:
+            raise ValueError(
+                f"duplicate bronze target name '{bronze_name}' — "
+                f"entries {seen_bronze_names[bronze_name]} and {origin} "
+                f"normalize to the same identifier. Use distinct aliases."
+            )
+        seen_bronze_names[bronze_name] = origin
+
+        timestamp_column = None
+        ts = entry.get("timestamp")
+        if ts and isinstance(ts, dict):
+            timestamp_column = ts.get("column")
+
+        tables.append(
+            TableConfig(
+                name=bronze_name,
+                source_table=entry["source_table"],
+                strategy=entry["strategy"],
+                target_table=f"bronze.{bronze_name}",
+                primary_key=entry.get("primary_key"),
+                timestamp_column=timestamp_column,
+                source_name=source_db,
+                database=source_db,
+            )
+        )
+
+    return tables

--- a/src/feather_etl/pipeline.py
+++ b/src/feather_etl/pipeline.py
@@ -169,6 +169,7 @@ def run_table(
     config: FeatherConfig,
     table: TableConfig,
     working_dir: Path,
+    source: object | None = None,
 ) -> RunResult:
     """Run a single table through the pipeline: extract → load → update state."""
     logger.info("Starting extraction", extra={"table": table.name})
@@ -205,7 +206,8 @@ def run_table(
     dest = DuckDBDestination(path=config.destination.path)
     dest.setup_schemas()
 
-    source = config.sources[0]
+    if source is None:
+        source = config.sources[0]
     effective_target = _resolve_target(table, config.mode)
 
     # Prod mode with column_map: extract only mapped columns
@@ -540,9 +542,16 @@ def run_all(
                 f"Available tables: {available}"
             )
 
+    from feather_etl.curation import resolve_source
+
     results: list[RunResult] = []
     for table in tables:
-        result = run_table(config, table, working_dir)
+        table_source = (
+            resolve_source(table.database, config.sources)
+            if table.database
+            else config.sources[0]
+        )
+        result = run_table(config, table, working_dir, source=table_source)
         results.append(result)
 
     # Post-extraction transforms (mode-dependent)

--- a/src/feather_etl/sources/expand.py
+++ b/src/feather_etl/sources/expand.py
@@ -1,0 +1,62 @@
+"""Shared database source expansion — used by discover and pipeline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.sources.database_source import DatabaseSource
+
+
+def expand_db_sources(sources: list) -> list:
+    """Expand database sources without explicit database into child sources.
+
+    For each source:
+      - File sources → keep as-is.
+      - DB source with `database` set → keep as-is.
+      - DB source with `databases: [...]` → one child per entry.
+      - DB source with neither → call list_databases() and expand.
+    """
+    expanded: list = []
+    for src in sources:
+        if not isinstance(src, DatabaseSource):
+            expanded.append(src)
+            continue
+        if src.database is not None:
+            expanded.append(src)
+            continue
+        databases = src.databases
+        if databases is None:
+            try:
+                databases = src.list_databases()
+            except Exception as e:
+                src._last_error = (
+                    f"Found 0 databases on host {src.host}. Either grant "
+                    f"VIEW ANY DATABASE to this login, or specify "
+                    f"`database:` / `databases: [...]` explicitly. ({e})"
+                )
+                expanded.append(src)
+                continue
+            if not databases:
+                src._last_error = (
+                    f"Found 0 databases on host {src.host}. Either grant "
+                    f"VIEW ANY DATABASE to this login, or specify "
+                    f"`database:` / `databases: [...]` explicitly."
+                )
+                expanded.append(src)
+                continue
+        for db in databases:
+            child = type(src).from_yaml(
+                {
+                    "name": f"{src.name}__{db}",
+                    "type": src.type,
+                    "host": src.host,
+                    "port": src.port,
+                    "user": src.user,
+                    "password": src.password,
+                    "database": db,
+                },
+                Path("."),
+            )
+            child._explicit_name = getattr(src, "_explicit_name", False)
+            expanded.append(child)
+    return expanded

--- a/src/feather_etl/sources/expand.py
+++ b/src/feather_etl/sources/expand.py
@@ -55,7 +55,7 @@ def expand_db_sources(sources: list) -> list:
                     "password": src.password,
                     "database": db,
                 },
-                Path("."),
+                Path("."),  # DB sources' from_yaml ignores config_dir (file-path only)
             )
             child._explicit_name = getattr(src, "_explicit_name", False)
             expanded.append(child)

--- a/tests/commands/conftest.py
+++ b/tests/commands/conftest.py
@@ -10,6 +10,7 @@ import yaml
 from typer.testing import CliRunner
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 @pytest.fixture
@@ -24,19 +25,17 @@ def cli_env(tmp_path: Path) -> tuple[Path, Path]:
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+        ],
+    )
     return config_path, tmp_path
 
 
@@ -47,25 +46,18 @@ def two_table_env(tmp_path: Path) -> tuple[Path, Path]:
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-            {
-                "name": "customer_master",
-                "source_table": "icube.CUSTOMERMASTER",
-                "target_table": "bronze.customer_master",
-                "strategy": "full",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+            make_curation_entry("icube", "icube.CUSTOMERMASTER", "customer_master"),
+        ],
+    )
     return config_path, tmp_path
 
 
@@ -74,19 +66,17 @@ def cli_config(tmp_path: Path) -> Path:
     client_db = tmp_path / "client.duckdb"
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            }
-        ],
     }
     config_file = tmp_path / "feather.yaml"
     config_file.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+        ],
+    )
     return config_file
 
 
@@ -101,15 +91,13 @@ def multi_source_yaml(
     tmp_path: Path,
     sources: list[dict],
     destination_path: str | None = None,
-    tables: list[dict] | None = None,
 ) -> Path:
-    """Build a feather.yaml with arbitrary sources/destinations/tables."""
+    """Build a feather.yaml with arbitrary sources/destinations."""
     cfg = {
         "sources": sources,
         "destination": {
             "path": destination_path or str(tmp_path / "feather_data.duckdb")
         },
-        "tables": tables or [],
     }
     p = tmp_path / "feather.yaml"
     p.write_text(yaml.dump(cfg, default_flow_style=False))

--- a/tests/commands/test_history.py
+++ b/tests/commands/test_history.py
@@ -23,18 +23,24 @@ class TestHistory:
         assert "customer_master" in result.output
 
     def test_history_table_filter(self, runner, two_table_env: tuple[Path, Path]):
-        """feather history --table inventory_group shows only that table's runs."""
+        """feather history --table icube_inventory_group shows only that table's runs."""
         from feather_etl.cli import app
 
         config_path, _ = two_table_env
         runner.invoke(app, ["run", "--config", str(config_path)])
         result = runner.invoke(
             app,
-            ["history", "--config", str(config_path), "--table", "inventory_group"],
+            [
+                "history",
+                "--config",
+                str(config_path),
+                "--table",
+                "icube_inventory_group",
+            ],
         )
         assert result.exit_code == 0
-        assert "inventory_group" in result.output
-        assert "customer_master" not in result.output
+        assert "icube_inventory_group" in result.output
+        assert "icube_customer_master" not in result.output
 
     def test_history_limit(self, runner, two_table_env: tuple[Path, Path]):
         """feather history --limit 1 shows at most 1 run."""

--- a/tests/commands/test_multi_source_guard.py
+++ b/tests/commands/test_multi_source_guard.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 def _multi_source_yaml(tmp_path: Path) -> Path:
@@ -21,17 +22,13 @@ def _multi_source_yaml(tmp_path: Path) -> Path:
             {"name": "b", "type": "duckdb", "path": str(src2)},
         ],
         "destination": {"path": str(tmp_path / "out.duckdb")},
-        "tables": [
-            {
-                "name": "ig",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.ig",
-                "strategy": "full",
-            },
-        ],
     }
     p = tmp_path / "feather.yaml"
     p.write_text(yaml.dump(cfg))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("a", "icube.InventoryGroup", "ig")],
+    )
     return p
 
 

--- a/tests/commands/test_multi_source_guard.py
+++ b/tests/commands/test_multi_source_guard.py
@@ -1,4 +1,4 @@
-"""Multi-source guard for non-discover commands (B2 deferral)."""
+"""Multi-source commands are now supported (guard removed in #8)."""
 
 from __future__ import annotations
 
@@ -32,44 +32,45 @@ def _multi_source_yaml(tmp_path: Path) -> Path:
     return p
 
 
-class TestMultiSourceGuard:
-    def test_validate_exits_2_with_guidance(self, runner, tmp_path):
+class TestMultiSource:
+    """Multi-source configs are accepted by all commands — the old single-source
+    guard was removed as part of issue #8 (multi-source pipeline support)."""
+
+    def test_validate_accepts_multi_source(self, runner, tmp_path):
         from feather_etl.cli import app
 
         cfg = _multi_source_yaml(tmp_path)
         r = runner.invoke(app, ["validate", "--config", str(cfg)])
-        assert r.exit_code == 2
-        assert "single-source" in r.output
-        assert "discover" in r.output
+        # No longer rejected — both sources should be checked
+        assert "single-source" not in r.output
+        assert r.exit_code in (0, 2)  # 0=all connected, 2=connection failure
 
-    def test_run_exits_2(self, runner, tmp_path):
+    def test_run_accepts_multi_source(self, runner, tmp_path):
         from feather_etl.cli import app
 
         cfg = _multi_source_yaml(tmp_path)
         r = runner.invoke(app, ["run", "--config", str(cfg)])
-        assert r.exit_code == 2
-        assert "single-source" in r.output
+        # No longer rejected at the guard level
+        assert "single-source" not in r.output
 
-    def test_status_exits_2(self, runner, tmp_path):
-        from feather_etl.cli import app
-
-        cfg = _multi_source_yaml(tmp_path)
-        r = runner.invoke(app, ["status", "--config", str(cfg)])
-        assert r.exit_code == 2
-        assert "single-source" in r.output
-
-    def test_history_exits_2(self, runner, tmp_path):
-        from feather_etl.cli import app
-
-        cfg = _multi_source_yaml(tmp_path)
-        r = runner.invoke(app, ["history", "--config", str(cfg)])
-        assert r.exit_code == 2
-        assert "single-source" in r.output
-
-    def test_setup_exits_2(self, runner, tmp_path):
+    def test_setup_accepts_multi_source(self, runner, tmp_path):
         from feather_etl.cli import app
 
         cfg = _multi_source_yaml(tmp_path)
         r = runner.invoke(app, ["setup", "--config", str(cfg)])
-        assert r.exit_code == 2
-        assert "single-source" in r.output
+        assert "single-source" not in r.output
+        assert r.exit_code == 0
+
+    def test_status_accepts_multi_source(self, runner, tmp_path):
+        from feather_etl.cli import app
+
+        cfg = _multi_source_yaml(tmp_path)
+        r = runner.invoke(app, ["status", "--config", str(cfg)])
+        assert "single-source" not in r.output
+
+    def test_history_accepts_multi_source(self, runner, tmp_path):
+        from feather_etl.cli import app
+
+        cfg = _multi_source_yaml(tmp_path)
+        r = runner.invoke(app, ["history", "--config", str(cfg)])
+        assert "single-source" not in r.output

--- a/tests/commands/test_run.py
+++ b/tests/commands/test_run.py
@@ -10,6 +10,7 @@ import yaml
 
 from tests.commands.conftest import cli_config
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestRun:
@@ -27,18 +28,14 @@ class TestRun:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "bad_table",
-                    "source_table": "icube.NONEXISTENT",
-                    "target_table": "bronze.bad_table",
-                    "strategy": "full",
-                },
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("icube", "icube.NONEXISTENT", "bad_table")],
+        )
         result = runner.invoke(app, ["run", "--config", str(tmp_path / "feather.yaml")])
         assert result.exit_code == 1
         assert "failure" in result.output.lower()
@@ -50,24 +47,17 @@ class TestRun:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "good_table",
-                    "source_table": "icube.SALESINVOICE",
-                    "target_table": "bronze.good_table",
-                    "strategy": "full",
-                },
-                {
-                    "name": "bad_table",
-                    "source_table": "nonexistent.NOPE",
-                    "target_table": "bronze.bad_table",
-                    "strategy": "full",
-                },
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry("icube", "icube.SALESINVOICE", "good_table"),
+                make_curation_entry("icube", "nonexistent.NOPE", "bad_table"),
+            ],
+        )
 
         result1 = runner.invoke(
             app, ["run", "--config", str(tmp_path / "feather.yaml")]
@@ -98,16 +88,23 @@ class TestTableFilter:
     def test_table_filter_extracts_only_matching_table(
         self, runner, two_table_env: tuple[Path, Path]
     ):
-        """--table inventory_group should extract only that table."""
+        """--table icube_inventory_group should extract only that table."""
         from feather_etl.cli import app
 
         config_path, tmp_path = two_table_env
         result = runner.invoke(
-            app, ["run", "--config", str(config_path), "--table", "inventory_group"]
+            app,
+            [
+                "run",
+                "--config",
+                str(config_path),
+                "--table",
+                "icube_inventory_group",
+            ],
         )
         assert result.exit_code == 0
-        assert "inventory_group" in result.output
-        assert "customer_master" not in result.output
+        assert "icube_inventory_group" in result.output
+        assert "icube_customer_master" not in result.output
 
     def test_table_filter_nonexistent_table_exits_with_error(
         self, runner, two_table_env: tuple[Path, Path]
@@ -134,8 +131,8 @@ class TestTableFilter:
         config_path, _ = two_table_env
         result = runner.invoke(app, ["run", "--config", str(config_path)])
         assert result.exit_code == 0
-        assert "inventory_group" in result.output
-        assert "customer_master" in result.output
+        assert "icube_inventory_group" in result.output
+        assert "icube_customer_master" in result.output
 
 
 class TestRunAutoCreates:

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -10,6 +10,7 @@ import yaml
 
 from tests.commands.conftest import cli_config
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestStatus:
@@ -20,7 +21,7 @@ class TestStatus:
         runner.invoke(app, ["run", "--config", str(config_path)])
         result = runner.invoke(app, ["status", "--config", str(config_path)])
         assert result.exit_code == 0
-        assert "inventory_group" in result.output
+        assert "icube_inventory_group" in result.output
 
     def test_status_no_state_db(self, runner, cli_env: tuple[Path, Path]):
         from feather_etl.cli import app
@@ -46,19 +47,15 @@ class TestStatus:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "bad_table",
-                    "source_table": "icube.NONEXISTENT",
-                    "target_table": "bronze.bad_table",
-                    "strategy": "full",
-                },
-            ],
         }
         config_path = tmp_path / "feather.yaml"
         config_path.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("icube", "icube.NONEXISTENT", "bad_table")],
+        )
 
         runner.invoke(app, ["run", "--config", str(config_path)])
         result = runner.invoke(app, ["status", "--config", str(config_path)])
@@ -73,41 +70,34 @@ class TestStatus:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
 
+        # First config: inventory_group
         config_a = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "inventory_group",
-                    "source_table": "icube.InventoryGroup",
-                    "target_table": "bronze.inventory_group",
-                    "strategy": "full",
-                },
-            ],
         }
         config_path = tmp_path / "feather.yaml"
         config_path.write_text(yaml.dump(config_a, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+            ],
+        )
         runner.invoke(app, ["run", "--config", str(config_path)])
 
-        config_b = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
-            "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customer_master",
-                    "source_table": "icube.CUSTOMERMASTER",
-                    "target_table": "bronze.customer_master",
-                    "strategy": "full",
-                },
+        # Second config: customer_master
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry("icube", "icube.CUSTOMERMASTER", "customer_master"),
             ],
-        }
-        config_path.write_text(yaml.dump(config_b, default_flow_style=False))
+        )
         runner.invoke(app, ["run", "--config", str(config_path)])
 
         result = runner.invoke(app, ["status", "--config", str(config_path)])
         assert result.exit_code == 0
-        assert "inventory_group" in result.output
-        assert "customer_master" in result.output
+        assert "icube_inventory_group" in result.output
+        assert "icube_customer_master" in result.output
 
     def test_status_json_outputs_ndjson(self, runner, tmp_path: Path):
         """AC-FR11.d: feather status --json outputs NDJSON with required fields."""

--- a/tests/commands/test_validate.py
+++ b/tests/commands/test_validate.py
@@ -28,7 +28,6 @@ class TestValidate:
                 {
                     "sources": [{"type": "mongodb", "path": "/nope"}],
                     "destination": {"path": "./data.duckdb"},
-                    "tables": [],
                 }
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from tests.helpers import make_curation_entry, write_curation
+
 
 def pytest_configure(config):
     """Start PostgreSQL before test collection (so skipif checks see it)."""
@@ -34,40 +36,29 @@ def client_db(tmp_path) -> Path:
 
 @pytest.fixture
 def config_path(client_db, tmp_path) -> Path:
-    """Write a feather.yaml pointing at client_db, return path."""
+    """Write a feather.yaml + curation.json pointing at client_db, return path."""
     config = {
         "sources": [
             {
                 "type": "duckdb",
+                "name": "icube",
                 "path": str(client_db),
             }
         ],
         "destination": {
             "path": str(tmp_path / "feather_data.duckdb"),
         },
-        "tables": [
-            {
-                "name": "sales_invoice",
-                "source_table": "icube.SALESINVOICE",
-                "target_table": "bronze.sales_invoice",
-                "strategy": "full",
-            },
-            {
-                "name": "customer_master",
-                "source_table": "icube.CUSTOMERMASTER",
-                "target_table": "bronze.customer_master",
-                "strategy": "full",
-            },
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-        ],
     }
     config_file = tmp_path / "feather.yaml"
     config_file.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [
+            make_curation_entry("icube", "icube.SALESINVOICE", "sales_invoice"),
+            make_curation_entry("icube", "icube.CUSTOMERMASTER", "customer_master"),
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+        ],
+    )
     return config_file
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,8 @@
 """Shared test utility functions."""
 
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
 import yaml
@@ -9,3 +12,58 @@ def write_config(tmp_path: Path, config: dict, directory: Path | None = None) ->
     config_file = (directory or tmp_path) / "feather.yaml"
     config_file.write_text(yaml.dump(config, default_flow_style=False))
     return config_file
+
+
+def write_curation(tmp_path: Path, tables: list[dict]) -> Path:
+    """Write a discovery/curation.json for testing."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test fixture",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    path = discovery_dir / "curation.json"
+    path.write_text(json.dumps(manifest))
+    return path
+
+
+def make_curation_entry(
+    source_db: str,
+    source_table: str,
+    alias: str,
+    strategy: str = "full",
+    primary_key: list[str] | None = None,
+    timestamp_column: str | None = None,
+    filter: str | None = None,
+    quality_checks: dict | None = None,
+    column_map: dict[str, str] | None = None,
+    dedup: bool = False,
+    dedup_columns: list[str] | None = None,
+    schedule: str | None = None,
+) -> dict:
+    """Create a curation.json include entry for testing."""
+    timestamp = None
+    if timestamp_column:
+        timestamp = {"column": timestamp_column, "reason": None, "rejected": []}
+    return {
+        "source_db": source_db,
+        "source_table": source_table,
+        "decision": "include",
+        "table_type": "fact",
+        "group": "test",
+        "alias": alias,
+        "classification_notes": None,
+        "strategy": strategy,
+        "primary_key": primary_key or ["id"],
+        "timestamp": timestamp,
+        "grain": None,
+        "scd": None,
+        "mapping": None,
+        "dq_policy": None,
+        "load_contract": None,
+        "reason": "test fixture",
+    }

--- a/tests/test_append.py
+++ b/tests/test_append.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 def _make_table(num_rows: int = 5, id_offset: int = 0) -> pa.Table:
@@ -24,7 +25,6 @@ def _make_table(num_rows: int = 5, id_offset: int = 0) -> pa.Table:
 
 class TestLoadAppend:
     def test_load_append_inserts_with_metadata(self, tmp_path: Path):
-        """load_append() inserts rows and adds ETL metadata columns."""
         from feather_etl.destinations.duckdb import DuckDBDestination
 
         db_path = tmp_path / "data.duckdb"
@@ -44,11 +44,10 @@ class TestLoadAppend:
         con.close()
 
         assert count == 5
-        assert row[0] is not None  # _etl_loaded_at set
-        assert row[1] == "run_001"  # _etl_run_id set
+        assert row[0] is not None
+        assert row[1] == "run_001"
 
     def test_load_append_accumulates_rows(self, tmp_path: Path):
-        """Calling load_append twice accumulates rows — does not replace."""
         from feather_etl.destinations.duckdb import DuckDBDestination
 
         db_path = tmp_path / "data.duckdb"
@@ -71,22 +70,19 @@ class TestLoadAppend:
         }
         con.close()
 
-        assert count == 8  # 5 + 3, not replaced
+        assert count == 8
         assert run_ids == {"run_001", "run_002"}
 
     def test_load_append_creates_table_if_not_exists(self, tmp_path: Path):
-        """First call creates the table; subsequent calls append without errors."""
         from feather_etl.destinations.duckdb import DuckDBDestination
 
         db_path = tmp_path / "data.duckdb"
         dest = DuckDBDestination(path=db_path)
         dest.setup_schemas()
 
-        # Table doesn't exist yet
         data = _make_table(2)
         dest.load_append("bronze.new_table", data, "run_001")
 
-        # Table exists now — append more
         dest.load_append("bronze.new_table", _make_table(3, id_offset=10), "run_002")
 
         con = duckdb.connect(str(db_path), read_only=True)
@@ -104,23 +100,26 @@ class TestPipelineAppendDispatch:
         source_table: str = "erp.customers",
     ) -> Path:
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customers",
-                    "source_table": source_table,
-                    "target_table": "bronze.customers",
-                    "strategy": strategy,
-                }
-            ],
         }
         config_path = tmp_path / "feather.yaml"
         config_path.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    source_table,
+                    "customers",
+                    strategy=strategy,
+                    primary_key=["customer_id"],
+                ),
+            ],
+        )
         return config_path
 
     def test_pipeline_dispatches_to_load_append(self, tmp_path: Path):
-        """run_table() with strategy=append calls load_append, not load_full."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_table
 
@@ -132,15 +131,14 @@ class TestPipelineAppendDispatch:
         result = run_table(cfg, cfg.tables[0], tmp_path)
 
         assert result.status == "success"
-        assert result.rows_loaded == 4  # erp.customers has 4 rows
+        assert result.rows_loaded == 4
 
         con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
-        count = con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+        count = con.execute("SELECT COUNT(*) FROM bronze.src_customers").fetchone()[0]
         con.close()
         assert count == 4
 
     def test_append_second_run_appends_on_change(self, tmp_path: Path):
-        """Run append twice with a source change — both batches accumulate."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
@@ -150,11 +148,9 @@ class TestPipelineAppendDispatch:
 
         cfg = load_config(config_path)
 
-        # First run: 4 rows loaded
         results1 = run_all(cfg, config_path)
         assert all(r.status == "success" for r in results1)
 
-        # Modify source: add 1 new row to trigger change detection
         time.sleep(0.05)
         con = duckdb.connect(str(source_db))
         con.execute(
@@ -162,19 +158,18 @@ class TestPipelineAppendDispatch:
         )
         con.close()
 
-        # Second run: detects change, appends 5 rows (4 original + 1 new)
         cfg2 = load_config(config_path)
         results2 = run_all(cfg2, config_path)
         assert all(r.status == "success" for r in results2)
 
         dest_con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
-        count = dest_con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+        count = dest_con.execute(
+            "SELECT COUNT(*) FROM bronze.src_customers"
+        ).fetchone()[0]
         dest_con.close()
-        # First run: 4 rows. Second run appends 5 rows (source now has 5). Total: 9.
         assert count == 9
 
     def test_append_unchanged_source_skips(self, tmp_path: Path):
-        """Run append twice without source change — second run is skipped."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
@@ -189,8 +184,9 @@ class TestPipelineAppendDispatch:
         results2 = run_all(cfg2, config_path)
         assert all(r.status == "skipped" for r in results2)
 
-        # Rows must still be 4 (not doubled)
         dest_con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
-        count = dest_con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+        count = dest_con.execute(
+            "SELECT COUNT(*) FROM bronze.src_customers"
+        ).fetchone()[0]
         dest_con.close()
         assert count == 4

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,27 +7,27 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests.helpers import write_config
+from tests.helpers import make_curation_entry, write_config, write_curation
 
 
 def _minimal_config(tmp_path: Path, source_path: str | None = None) -> dict:
-    """Return a valid minimal config dict."""
+    """Return a valid minimal config dict (no tables — those come from curation)."""
     if source_path is None:
         db = tmp_path / "source.duckdb"
         db.touch()
         source_path = str(db)
     return {
-        "sources": [{"type": "duckdb", "path": source_path}],
+        "sources": [{"type": "duckdb", "name": "src", "path": source_path}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "test_table",
-                "source_table": "main.test",
-                "target_table": "bronze.test_table",
-                "strategy": "full",
-            }
-        ],
     }
+
+
+def _minimal_curation(tmp_path: Path) -> None:
+    """Write a minimal curation.json with one table."""
+    write_curation(
+        tmp_path,
+        [make_curation_entry("src", "main.test", "test_table")],
+    )
 
 
 class TestConfigParsing:
@@ -36,10 +36,11 @@ class TestConfigParsing:
 
         cfg = _minimal_config(tmp_path)
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.sources[0].type == "duckdb"
         assert len(result.tables) == 1
-        assert result.tables[0].name == "test_table"
+        assert result.tables[0].name == "src_test_table"
 
     def test_env_var_substitution(self, tmp_path: Path):
         from feather_etl.config import load_config
@@ -49,6 +50,7 @@ class TestConfigParsing:
             cfg = _minimal_config(tmp_path)
             cfg["sources"][0]["path"] = "${FEATHER_TEST_PATH}"
             config_file = write_config(tmp_path, cfg)
+            _minimal_curation(tmp_path)
             result = load_config(config_file, validate=False)
             assert "${" not in str(result.sources[0].path)
             assert "source.duckdb" in str(result.sources[0].path)
@@ -64,64 +66,24 @@ class TestConfigParsing:
         cfg["sources"][0]["path"] = "./source.duckdb"
         cfg["destination"]["path"] = "./data.duckdb"
         config_file = write_config(tmp_path, cfg, directory=subdir)
+        write_curation(
+            subdir,
+            [make_curation_entry("src", "main.test", "test_table")],
+        )
         result = load_config(config_file, validate=False)
         assert result.sources[0].path == subdir / "source.duckdb"
         assert result.destination.path == subdir / "data.duckdb"
-
-    def test_target_table_defaults_to_silver(self, tmp_path: Path):
-        from feather_etl.config import load_config
-
-        cfg = _minimal_config(tmp_path)
-        del cfg["tables"][0]["target_table"]
-        config_file = write_config(tmp_path, cfg)
-        result = load_config(config_file, validate=False)
-        assert result.tables[0].target_table == ""  # mode-derived at runtime
-
-    def test_tables_directory_merge(self, tmp_path: Path):
-        from feather_etl.config import load_config
-
-        db = tmp_path / "source.duckdb"
-        cfg = {
-            "sources": [{"type": "duckdb", "path": str(db)}],
-            "destination": {"path": str(tmp_path / "data.duckdb")},
-            "tables": [
-                {
-                    "name": "inline_table",
-                    "source_table": "main.inline",
-                    "target_table": "bronze.inline_table",
-                    "strategy": "full",
-                }
-            ],
-        }
-        config_file = write_config(tmp_path, cfg)
-
-        tables_dir = tmp_path / "tables"
-        tables_dir.mkdir()
-        extra = {
-            "tables": [
-                {
-                    "name": "dir_table",
-                    "source_table": "main.dir",
-                    "target_table": "bronze.dir_table",
-                    "strategy": "full",
-                }
-            ]
-        }
-        (tables_dir / "extra.yaml").write_text(yaml.dump(extra))
-
-        result = load_config(config_file, validate=False)
-        names = {t.name for t in result.tables}
-        assert names == {"inline_table", "dir_table"}
 
     def test_no_primary_key_does_not_error(self, tmp_path: Path):
         """primary_key validation deferred to Slice 3."""
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        # No primary_key field at all
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
-        assert result.tables[0].primary_key is None
+        # curation entries have primary_key=["id"] by default
+        assert result.tables[0].primary_key == ["id"]
 
 
 class TestConfigValidation:
@@ -131,41 +93,48 @@ class TestConfigValidation:
         cfg = _minimal_config(tmp_path)
         cfg["sources"][0]["type"] = "mongodb"
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="not implemented"):
             load_config(config_file)
 
     def test_missing_source_path_for_file_source(self, tmp_path: Path):
-        """Load succeeds but source.check() reports the path is unreachable.
-
-        Per Task 1.8 / spec §5.2 (side-effect-free from_yaml): path-existence
-        is a runtime concern handled by source.check(), not a load-time check.
-        """
+        """Load succeeds but source.check() reports the path is unreachable."""
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
         cfg["sources"][0]["path"] = str(tmp_path / "nonexistent.duckdb")
-        # do NOT create the file
         config_file = write_config(tmp_path, cfg)
-        cfg_result = load_config(config_file)  # now succeeds
+        _minimal_curation(tmp_path)
+        cfg_result = load_config(config_file)
         assert cfg_result.sources[0].check() is False
 
     def test_bad_strategy(self, tmp_path: Path):
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["strategy"] = "upsert"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "main.test", "test_table", strategy="upsert")],
+        )
         with pytest.raises(ValueError, match="strategy"):
             load_config(config_file)
 
     def test_bad_target_schema_prefix(self, tmp_path: Path):
+        """Curation always produces bronze.* targets, so this test validates
+        directly via _validate with a manually-constructed table."""
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["target_table"] = "staging.test_table"
         config_file = write_config(tmp_path, cfg)
-        with pytest.raises(ValueError, match="schema"):
-            load_config(config_file)
+        _minimal_curation(tmp_path)
+        result = load_config(config_file, validate=False)
+        # Manually override to test validation
+        result.tables[0].target_table = "staging.test_table"
+        from feather_etl.config import _validate
+
+        errors = _validate(result)
+        assert any("schema" in e for e in errors)
 
 
 class TestValidationJson:
@@ -174,6 +143,7 @@ class TestValidationJson:
 
         cfg = _minimal_config(tmp_path)
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file)
         write_validation_json(config_file, result)
         vj = json.loads((tmp_path / "feather_validation.json").read_text())
@@ -200,57 +170,39 @@ class TestEnvVarEdgeCases:
         cfg = _minimal_config(tmp_path)
         cfg["defaults"] = {"overlap_window_minutes": 5, "batch_size": 50000}
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.defaults.overlap_window_minutes == 5
         assert result.defaults.batch_size == 50000
 
     def test_dotenv_auto_loaded_from_config_dir(self, tmp_path: Path, monkeypatch):
-        """Regression for siraj-samsudeen/feather-etl#1.
-
-        A `.env` file next to `feather.yaml` should be loaded automatically,
-        so users don't have to manually `export` variables before running
-        `feather validate`, `feather run`, etc. Without this, `${VAR}`
-        references in feather.yaml fall back to `os.environ` only.
-        """
+        """Regression for siraj-samsudeen/feather-etl#1."""
         from feather_etl.config import load_config
 
-        # Ensure the var is NOT already in the environment
         monkeypatch.delenv("FEATHER_TEST_DOTENV_VAR", raising=False)
-        assert (
-            "FEATHER_TEST_DOTENV_VAR" not in os.environ
-        )  # must come from .env, not shell
+        assert "FEATHER_TEST_DOTENV_VAR" not in os.environ
 
-        # Write .env alongside the config — this is what should get auto-loaded
-        (tmp_path / ".env").write_text("FEATHER_TEST_DOTENV_VAR=bronze\n")
+        (tmp_path / ".env").write_text("FEATHER_TEST_DOTENV_VAR=hello\n")
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["target_table"] = "${FEATHER_TEST_DOTENV_VAR}.t"
         config_file = write_config(tmp_path, cfg)
-
-        result = load_config(config_file, validate=False)
-        # If .env was loaded, ${FEATHER_TEST_DOTENV_VAR} resolved to "bronze"
-        assert result.tables[0].target_table == "bronze.t"
+        _minimal_curation(tmp_path)
+        load_config(config_file, validate=False)
+        # Just verify .env was loaded — the variable was resolved
+        assert os.environ.get("FEATHER_TEST_DOTENV_VAR") == "hello"
 
     def test_dotenv_does_not_override_existing_env(self, tmp_path: Path, monkeypatch):
-        """Existing shell/CI env vars must win over .env (override=False).
-
-        Important for CI/CD: secrets come from the environment, not a
-        committed .env file. A stray committed .env must not silently
-        clobber what the pipeline passes in.
-        """
+        """Existing shell/CI env vars must win over .env (override=False)."""
         from feather_etl.config import load_config
 
-        # Simulate CI env variable setup
         monkeypatch.setenv("FEATHER_TEST_OVERRIDE_VAR", "gold")
-
         (tmp_path / ".env").write_text("FEATHER_TEST_OVERRIDE_VAR=bronze\n")
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["target_table"] = "${FEATHER_TEST_OVERRIDE_VAR}.t"
         config_file = write_config(tmp_path, cfg)
-
-        result = load_config(config_file, validate=False)
-        assert result.tables[0].target_table == "gold.t"
+        _minimal_curation(tmp_path)
+        load_config(config_file, validate=False)
+        assert os.environ["FEATHER_TEST_OVERRIDE_VAR"] == "gold"
 
     def test_unresolved_env_var_gives_clear_error(self, tmp_path: Path):
         """UX-4: Unset env vars should show which variable is missing."""
@@ -259,6 +211,7 @@ class TestEnvVarEdgeCases:
         cfg = _minimal_config(tmp_path)
         cfg["destination"]["path"] = "${MISSING_DEST_PATH}"
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="MISSING_DEST_PATH"):
             load_config(config_file, validate=False)
 
@@ -271,38 +224,10 @@ class TestConfigValidationExtended:
         cfg = {
             "sources": [{"type": "ftp", "connection_string": "ftp://example.com"}],
             "destination": {"path": str(tmp_path / "data.duckdb")},
-            "tables": [
-                {
-                    "name": "t",
-                    "source_table": "main.t",
-                    "target_table": "bronze.t",
-                    "strategy": "full",
-                },
-            ],
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="not implemented"):
-            load_config(config_file)
-
-    def test_missing_table_field_gives_friendly_error(self, tmp_path: Path):
-        """BUG-4: Missing required table fields should raise ValueError, not KeyError."""
-        from feather_etl.config import load_config
-
-        db = tmp_path / "source.duckdb"
-        db.touch()
-        cfg = {
-            "sources": [{"type": "duckdb", "path": str(db)}],
-            "destination": {"path": str(tmp_path / "data.duckdb")},
-            "tables": [
-                {
-                    "name": "t",
-                    "source_table": "main.t",
-                    "target_table": "bronze.t",
-                },  # strategy missing
-            ],
-        }
-        config_file = write_config(tmp_path, cfg)
-        with pytest.raises(ValueError, match="missing required field"):
             load_config(config_file)
 
     def test_missing_source_section_gives_friendly_error(self, tmp_path: Path):
@@ -311,7 +236,6 @@ class TestConfigValidationExtended:
 
         cfg = {
             "destination": {"path": str(tmp_path / "data.duckdb")},
-            "tables": [],
         }
         config_file = write_config(tmp_path, cfg)
         with pytest.raises(ValueError, match="Missing required config section"):
@@ -324,43 +248,14 @@ class TestConfigValidationExtended:
         db = tmp_path / "source.duckdb"
         db.touch()
         cfg = {
-            "sources": [{"type": "duckdb", "path": str(db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(db)}],
             "destination": {
                 "path": str(tmp_path / "nonexistent" / "sub" / "data.duckdb")
             },
-            "tables": [
-                {
-                    "name": "t",
-                    "source_table": "main.t",
-                    "target_table": "bronze.t",
-                    "strategy": "full",
-                },
-            ],
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="Destination directory does not exist"):
-            load_config(config_file)
-
-    def test_hyphenated_target_table_rejected(self, tmp_path: Path):
-        """BUG-7: Hyphens in target table names should be caught at validate."""
-        from feather_etl.config import load_config
-
-        db = tmp_path / "source.duckdb"
-        db.touch()
-        cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["target_table"] = "bronze.my-hyphenated-table"
-        config_file = write_config(tmp_path, cfg)
-        with pytest.raises(ValueError, match="invalid characters"):
-            load_config(config_file)
-
-    def test_target_table_requires_schema_prefix(self, tmp_path: Path):
-        """BUG-7: target_table without schema prefix should be rejected."""
-        from feather_etl.config import load_config
-
-        cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["target_table"] = "no_schema_table"
-        config_file = write_config(tmp_path, cfg)
-        with pytest.raises(ValueError, match="must include a schema prefix"):
             load_config(config_file)
 
     def test_incremental_requires_timestamp_column(self, tmp_path: Path):
@@ -368,9 +263,15 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["strategy"] = "incremental"
-        # No timestamp_column
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src", "main.test", "test_table", strategy="incremental"
+                )
+            ],
+        )
         with pytest.raises(ValueError, match="timestamp_column"):
             load_config(config_file)
 
@@ -379,9 +280,19 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["strategy"] = "incremental"
-        cfg["tables"][0]["timestamp_column"] = "modified_date"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "main.test",
+                    "test_table",
+                    strategy="incremental",
+                    timestamp_column="modified_date",
+                ),
+            ],
+        )
         result = load_config(config_file)
         assert result.tables[0].strategy == "incremental"
 
@@ -392,6 +303,7 @@ class TestConfigValidationExtended:
         cfg = _minimal_config(tmp_path)
         cfg["defaults"] = {"overlap_window_minutes": -5}
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="overlap_window_minutes"):
             load_config(config_file)
 
@@ -402,6 +314,7 @@ class TestConfigValidationExtended:
         cfg = _minimal_config(tmp_path)
         cfg["defaults"] = {"overlap_window_minutes": 0}
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file)
         assert result.defaults.overlap_window_minutes == 0
 
@@ -410,8 +323,11 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "main.test; DROP TABLE foo"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "main.test; DROP TABLE foo", "test_table")],
+        )
         with pytest.raises(ValueError, match="source_table.*invalid"):
             load_config(config_file)
 
@@ -420,8 +336,11 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "main.test--comment"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "main.test--comment", "test_table")],
+        )
         with pytest.raises(ValueError, match="source_table.*invalid"):
             load_config(config_file)
 
@@ -429,10 +348,12 @@ class TestConfigValidationExtended:
         """M-1: legitimate source_table formats should pass validation."""
         from feather_etl.config import load_config
 
-        # schema.table format (DuckDB)
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "erp.SalesInvoice"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.SalesInvoice", "sales_invoice")],
+        )
         result = load_config(config_file)
         assert result.tables[0].source_table == "erp.SalesInvoice"
 
@@ -443,9 +364,12 @@ class TestConfigValidationExtended:
         csv_dir = tmp_path / "csv_data"
         csv_dir.mkdir()
         cfg = _minimal_config(tmp_path)
-        cfg["sources"] = [{"type": "csv", "path": str(csv_dir)}]
-        cfg["tables"][0]["source_table"] = "orders.csv"
+        cfg["sources"] = [{"type": "csv", "name": "csvs", "path": str(csv_dir)}]
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
+        )
         result = load_config(config_file)
         assert result.tables[0].source_table == "orders.csv"
 
@@ -454,8 +378,11 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "just_a_table"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "just_a_table", "test_table")],
+        )
         with pytest.raises(ValueError, match="source_table.*schema\\.table"):
             load_config(config_file)
 
@@ -464,8 +391,11 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "erp.Sales Invoice"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.Sales Invoice", "test_table")],
+        )
         with pytest.raises(ValueError, match="source_table.*invalid"):
             load_config(config_file)
 
@@ -474,8 +404,11 @@ class TestConfigValidationExtended:
         from feather_etl.config import load_config
 
         cfg = _minimal_config(tmp_path)
-        cfg["tables"][0]["source_table"] = "erp.test()"
         config_file = write_config(tmp_path, cfg)
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.test()", "test_table")],
+        )
         with pytest.raises(ValueError, match="source_table.*invalid"):
             load_config(config_file)
 
@@ -486,6 +419,7 @@ class TestAlertsConfig:
 
         cfg = _minimal_config(tmp_path)
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.alerts is None
 
@@ -501,6 +435,7 @@ class TestAlertsConfig:
             "alert_to": "ops@example.com",
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.alerts is not None
         assert result.alerts.smtp_host == "smtp.example.com"
@@ -520,6 +455,7 @@ class TestAlertsConfig:
             "alert_to": "ops@example.com",
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.alerts.alert_from == "user@example.com"
 
@@ -536,6 +472,7 @@ class TestAlertsConfig:
             "alert_from": "noreply@example.com",
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.alerts.alert_from == "noreply@example.com"
 
@@ -545,9 +482,9 @@ class TestAlertsConfig:
         cfg = _minimal_config(tmp_path)
         cfg["alerts"] = {
             "smtp_host": "smtp.example.com",
-            # missing smtp_port, smtp_user, smtp_password, alert_to
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         with pytest.raises(ValueError, match="alerts.*missing"):
             load_config(config_file, validate=False)
 
@@ -564,6 +501,7 @@ class TestAlertsConfig:
             "alert_to": "ops@example.com",
         }
         config_file = write_config(tmp_path, cfg)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.alerts.smtp_password == "env_secret"
 
@@ -574,10 +512,10 @@ class TestSourceName:
         from feather_etl.config import load_config
 
         cfg_dict = _minimal_config(tmp_path)
+        del cfg_dict["sources"][0]["name"]
         config_file = write_config(tmp_path, cfg_dict)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
-        # When name is omitted, auto-derivation produces '<type>-<basename-without-ext>'.
-        # Fixture path is '<tmp>/source.duckdb' → derived name is 'duckdb-source'.
         assert result.sources[0].name == "duckdb-source"
 
     def test_source_name_is_accepted(self, tmp_path: Path):
@@ -586,6 +524,7 @@ class TestSourceName:
         cfg_dict = _minimal_config(tmp_path)
         cfg_dict["sources"][0]["name"] = "prod-erp"
         config_file = write_config(tmp_path, cfg_dict)
+        _minimal_curation(tmp_path)
         result = load_config(config_file, validate=False)
         assert result.sources[0].name == "prod-erp"
 
@@ -597,7 +536,6 @@ class TestSourcesList:
         cfg_dict = {
             "sources": [{"type": "duckdb", "path": str(tmp_path / "s.duckdb")}],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         (tmp_path / "s.duckdb").write_bytes(b"")
         config_file = tmp_path / "feather.yaml"
@@ -615,7 +553,6 @@ class TestSourcesList:
                 {"type": "duckdb", "path": str(tmp_path / "b.duckdb")},
             ],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         for f in ("a.duckdb", "b.duckdb"):
             (tmp_path / f).write_bytes(b"")
@@ -633,7 +570,6 @@ class TestSourcesList:
                 {"name": "b", "type": "duckdb", "path": str(tmp_path / "b.duckdb")},
             ],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         for f in ("a.duckdb", "b.duckdb"):
             (tmp_path / f).write_bytes(b"")
@@ -651,7 +587,6 @@ class TestSourcesList:
                 {"name": "x", "type": "duckdb", "path": str(tmp_path / "b.duckdb")},
             ],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         for f in ("a.duckdb", "b.duckdb"):
             (tmp_path / f).write_bytes(b"")
@@ -666,7 +601,6 @@ class TestSourcesList:
         cfg_dict = {
             "sources": [],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(cfg_dict))
@@ -679,7 +613,6 @@ class TestSourcesList:
         cfg_dict = {
             "sources": [None],
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(cfg_dict))
@@ -694,7 +627,6 @@ class TestSingularSourceMigrationError:
         cfg_dict = {
             "source": {"type": "duckdb", "path": str(tmp_path / "s.duckdb")},
             "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [],
         }
         (tmp_path / "s.duckdb").write_bytes(b"")
         config_file = tmp_path / "feather.yaml"

--- a/tests/test_csv_glob.py
+++ b/tests/test_csv_glob.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 GLOB_FIXTURES = FIXTURES_DIR / "csv_glob"
@@ -22,23 +23,19 @@ class TestCsvGlobExtraction:
         data_dir = tmp_path / "data"
         shutil.copytree(GLOB_FIXTURES, data_dir)
         config = {
-            "sources": [{"type": "csv", "path": str(data_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(data_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "sales",
-                    "source_table": "sales_*.csv",
-                    "target_table": "bronze.sales",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "sales_*.csv", "sales")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        assert result.rows_loaded == 5  # 3 from jan + 2 from feb
+        assert result.rows_loaded == 5
 
     def test_glob_no_match_fails(self, tmp_path: Path):
         """Glob that matches no files should fail gracefully."""
@@ -47,24 +44,19 @@ class TestCsvGlobExtraction:
 
         data_dir = tmp_path / "data"
         data_dir.mkdir()
-        (data_dir / "other.csv").write_text("id\n1\n")  # No sales_* files
+        (data_dir / "other.csv").write_text("id\n1\n")
         config = {
-            "sources": [{"type": "csv", "path": str(data_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(data_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "sales",
-                    "source_table": "sales_*.csv",
-                    "target_table": "bronze.sales",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "sales_*.csv", "sales")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
-        # No matching files → change detection returns unchanged → skipped
         assert result.status == "skipped"
 
 
@@ -77,18 +69,14 @@ class TestCsvGlobChangeDetection:
         data_dir = tmp_path / "data"
         shutil.copytree(GLOB_FIXTURES, data_dir)
         config = {
-            "sources": [{"type": "csv", "path": str(data_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(data_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "sales",
-                    "source_table": "sales_*.csv",
-                    "target_table": "bronze.sales",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "sales_*.csv", "sales")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         run_table(cfg, cfg.tables[0], tmp_path)
@@ -103,30 +91,25 @@ class TestCsvGlobChangeDetection:
         data_dir = tmp_path / "data"
         shutil.copytree(GLOB_FIXTURES, data_dir)
         config = {
-            "sources": [{"type": "csv", "path": str(data_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(data_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "sales",
-                    "source_table": "sales_*.csv",
-                    "target_table": "bronze.sales",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "sales_*.csv", "sales")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Add a new file
         (data_dir / "sales_mar.csv").write_text(
             "order_id,customer,amount,month\n6,Frank,400,mar\n"
         )
 
         result2 = run_table(cfg, cfg.tables[0], tmp_path)
         assert result2.status == "success"
-        assert result2.rows_loaded == 6  # 3 + 2 + 1
+        assert result2.rows_loaded == 6
 
     def test_modified_file_triggers_reextract(self, tmp_path: Path):
         """Modifying a matching file should trigger re-extraction."""
@@ -137,23 +120,18 @@ class TestCsvGlobChangeDetection:
         data_dir = tmp_path / "data"
         shutil.copytree(GLOB_FIXTURES, data_dir)
         config = {
-            "sources": [{"type": "csv", "path": str(data_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(data_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "sales",
-                    "source_table": "sales_*.csv",
-                    "target_table": "bronze.sales",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "sales_*.csv", "sales")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Modify an existing file
         time.sleep(0.1)
         (data_dir / "sales_jan.csv").write_text(
             "order_id,customer,amount,month\n1,Alice,100,jan\n2,Bob,200,jan\n"
@@ -161,7 +139,7 @@ class TestCsvGlobChangeDetection:
 
         result2 = run_table(cfg, cfg.tables[0], tmp_path)
         assert result2.status == "success"
-        assert result2.rows_loaded == 4  # 2 from modified jan + 2 from feb
+        assert result2.rows_loaded == 4
 
 
 class TestCsvGlobDiscover:
@@ -173,7 +151,6 @@ class TestCsvGlobDiscover:
         shutil.copytree(GLOB_FIXTURES, data_dir)
         source = CsvSource(data_dir)
         schemas = source.discover()
-        # Should include individual files as before
         names = [s.name for s in schemas]
         assert "sales_jan.csv" in names
         assert "sales_feb.csv" in names

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -8,8 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from feather_etl.config import TableConfig
-
 
 def _write_curation(
     tmp_path: Path, tables: list[dict], source_systems: dict | None = None
@@ -79,7 +77,7 @@ class TestLoadCuration:
         _write_curation(tmp_path, [entry])
         result = load_curation_tables(tmp_path)
         assert result[0].name == "gofrugal_sales"
-        assert result[0].target_table == "bronze.gofrugal_sales"
+        assert result[0].target_table == ""  # mode-derived at runtime
 
     def test_maps_strategy(self, tmp_path: Path):
         from feather_etl.curation import load_curation_tables

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -1,0 +1,224 @@
+"""Tests for curation.json loader and source resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from feather_etl.config import TableConfig
+
+
+def _write_curation(
+    tmp_path: Path, tables: list[dict], source_systems: dict | None = None
+) -> Path:
+    """Write a minimal curation.json for testing."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": source_systems or {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    path = discovery_dir / "curation.json"
+    path.write_text(json.dumps(manifest, indent=2))
+    return path
+
+
+def _make_include_entry(
+    source_db: str = "test_db",
+    source_table: str = "dbo.Sales",
+    alias: str = "sales",
+    strategy: str = "full",
+    primary_key: list[str] | None = None,
+    timestamp: dict | None = None,
+) -> dict:
+    return {
+        "source_db": source_db,
+        "source_table": source_table,
+        "decision": "include",
+        "table_type": "fact",
+        "group": "test",
+        "alias": alias,
+        "classification_notes": None,
+        "strategy": strategy,
+        "primary_key": primary_key or ["id"],
+        "timestamp": timestamp,
+        "grain": None,
+        "scd": None,
+        "mapping": None,
+        "dq_policy": None,
+        "load_contract": None,
+        "reason": "test entry",
+    }
+
+
+class TestLoadCuration:
+    def test_filters_to_include_only(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(alias="sales"),
+            {**_make_include_entry(alias="excluded"), "decision": "exclude"},
+            {**_make_include_entry(alias="review"), "decision": "review"},
+        ]
+        _write_curation(tmp_path, tables)
+        result = load_curation_tables(tmp_path)
+        assert len(result) == 1
+        assert result[0].name == "test_db_sales"
+
+    def test_derives_bronze_name_from_source_db_and_alias(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="Gofrugal", alias="sales")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].name == "gofrugal_sales"
+        assert result[0].target_table == "bronze.gofrugal_sales"
+
+    def test_maps_strategy(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(
+            strategy="incremental",
+            timestamp={"column": "SyncDate", "reason": None, "rejected": []},
+        )
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].strategy == "incremental"
+        assert result[0].timestamp_column == "SyncDate"
+
+    def test_maps_primary_key(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(primary_key=["record_no", "line_no"])
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].primary_key == ["record_no", "line_no"]
+
+    def test_sets_source_name_and_database(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="SAP")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        assert result[0].database == "SAP"
+
+    def test_missing_curation_raises(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        with pytest.raises(FileNotFoundError, match="discovery/curation.json"):
+            load_curation_tables(tmp_path)
+
+    def test_no_include_entries_raises(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = {**_make_include_entry(), "decision": "exclude"}
+        _write_curation(tmp_path, [entry])
+        with pytest.raises(ValueError, match="No tables with decision.*include"):
+            load_curation_tables(tmp_path)
+
+    def test_sanitizes_bronze_name(self, tmp_path: Path):
+        from feather_etl.curation import load_curation_tables
+
+        entry = _make_include_entry(source_db="My-Source", alias="Sales Data!")
+        _write_curation(tmp_path, [entry])
+        result = load_curation_tables(tmp_path)
+        # Should be lowercased and sanitized
+        assert result[0].name == "my_source_sales_data_"
+
+    def test_bronze_name_collision_case_difference_raises(self, tmp_path: Path):
+        """Two aliases that differ only in case must collide after normalization."""
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(source_db="SAP", alias="Sales"),
+            _make_include_entry(source_db="SAP", alias="sales"),
+        ]
+        _write_curation(tmp_path, tables)
+        with pytest.raises(ValueError, match="duplicate bronze.*sap_sales"):
+            load_curation_tables(tmp_path)
+
+    def test_bronze_name_collision_punctuation_difference_raises(self, tmp_path: Path):
+        """Two aliases that differ only in punctuation must collide after normalization."""
+        from feather_etl.curation import load_curation_tables
+
+        tables = [
+            _make_include_entry(source_db="SAP", alias="sales_b"),
+            _make_include_entry(source_db="SAP", alias="sales-b"),
+        ]
+        _write_curation(tmp_path, tables)
+        with pytest.raises(ValueError, match="duplicate bronze.*sap_sales_b"):
+            load_curation_tables(tmp_path)
+
+
+class TestResolveSource:
+    def test_resolves_source_by_databases_list(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "Rama"
+        mock_src.database = None
+        mock_src.databases = ["Gofrugal", "SAP", "ZAKYA"]
+        mock_src.type = "sqlserver"
+
+        result = resolve_source("Gofrugal", [mock_src])
+        assert result == mock_src
+
+    def test_resolves_source_by_single_database(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "erp"
+        mock_src.database = "mydb"
+        mock_src.databases = None
+
+        result = resolve_source("mydb", [mock_src])
+        assert result == mock_src
+
+    def test_resolves_file_source_by_name(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "csv_data"
+        mock_src.database = None
+        mock_src.databases = None
+        # File source — no database attribute logic, matched by name
+        del mock_src.database
+        del mock_src.databases
+        mock_src.name = "csv_data"
+
+        result = resolve_source("csv_data", [mock_src])
+        assert result == mock_src
+
+    def test_no_match_raises(self):
+        from feather_etl.curation import resolve_source
+
+        mock_src = MagicMock()
+        mock_src.name = "Rama"
+        mock_src.database = None
+        mock_src.databases = ["Gofrugal"]
+
+        with pytest.raises(ValueError, match="does not match any declared source"):
+            resolve_source("NonExistent", [mock_src])
+
+    def test_ambiguous_match_raises(self):
+        from feather_etl.curation import resolve_source
+
+        src_a = MagicMock()
+        src_a.name = "ServerA"
+        src_a.database = None
+        src_a.databases = ["sales"]
+
+        src_b = MagicMock()
+        src_b.name = "ServerB"
+        src_b.database = None
+        src_b.databases = ["sales"]
+
+        with pytest.raises(ValueError, match="ambiguous.*matches multiple sources"):
+            resolve_source("sales", [src_a, src_b])

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -108,6 +108,7 @@ class TestLoadCuration:
         _write_curation(tmp_path, [entry])
         result = load_curation_tables(tmp_path)
         assert result[0].database == "SAP"
+        assert result[0].source_name == "SAP"
 
     def test_missing_curation_raises(self, tmp_path: Path):
         from feather_etl.curation import load_curation_tables

--- a/tests/test_curation_config_integration.py
+++ b/tests/test_curation_config_integration.py
@@ -1,0 +1,142 @@
+"""Tests for curation.json integration with load_config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import pytest
+import yaml
+
+
+def _write_feather_yaml(tmp_path: Path, sources: list[dict]) -> Path:
+    """Write a feather.yaml with sources and destination, no tables."""
+    config = {
+        "sources": sources,
+        "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+    }
+    config_file = tmp_path / "feather.yaml"
+    config_file.write_text(yaml.dump(config, default_flow_style=False))
+    return config_file
+
+
+def _write_curation(tmp_path: Path, tables: list[dict]) -> None:
+    """Write discovery/curation.json."""
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir(exist_ok=True)
+    manifest = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": tables,
+    }
+    (discovery_dir / "curation.json").write_text(json.dumps(manifest))
+
+
+def _make_include(
+    source_db: str,
+    source_table: str,
+    alias: str,
+    strategy: str = "full",
+) -> dict:
+    return {
+        "source_db": source_db,
+        "source_table": source_table,
+        "decision": "include",
+        "table_type": "fact",
+        "group": "test",
+        "alias": alias,
+        "classification_notes": None,
+        "strategy": strategy,
+        "primary_key": ["id"],
+        "timestamp": None,
+        "grain": None,
+        "scd": None,
+        "mapping": None,
+        "dq_policy": None,
+        "load_contract": None,
+        "reason": "test",
+    }
+
+
+class TestLoadConfigWithCuration:
+    def test_loads_tables_from_curation_json(self, tmp_path: Path):
+        from feather_etl.config import load_config
+
+        src_db = tmp_path / "source.duckdb"
+        con = duckdb.connect(str(src_db))
+        con.execute("CREATE SCHEMA erp")
+        con.execute("CREATE TABLE erp.orders (id INT, amount DOUBLE)")
+        con.execute("INSERT INTO erp.orders VALUES (1, 100.0)")
+        con.close()
+
+        config_file = _write_feather_yaml(
+            tmp_path,
+            [
+                {"type": "duckdb", "name": "erp", "path": str(src_db)},
+            ],
+        )
+        _write_curation(
+            tmp_path,
+            [
+                _make_include("erp", "erp.orders", "orders"),
+            ],
+        )
+
+        cfg = load_config(config_file, validate=False)
+        assert len(cfg.tables) == 1
+        assert cfg.tables[0].name == "erp_orders"
+        assert cfg.tables[0].target_table == ""  # mode-derived at runtime
+        assert cfg.tables[0].source_table == "erp.orders"
+        assert cfg.tables[0].database == "erp"
+
+    def test_multi_source_loads_from_curation(self, tmp_path: Path):
+        from feather_etl.config import load_config
+
+        src_a = tmp_path / "source_a.duckdb"
+        con = duckdb.connect(str(src_a))
+        con.execute("CREATE TABLE main.items (id INT)")
+        con.close()
+
+        src_b = tmp_path / "source_b.duckdb"
+        con = duckdb.connect(str(src_b))
+        con.execute("CREATE TABLE main.users (id INT)")
+        con.close()
+
+        config_file = _write_feather_yaml(
+            tmp_path,
+            [
+                {"type": "duckdb", "name": "inventory", "path": str(src_a)},
+                {"type": "duckdb", "name": "crm", "path": str(src_b)},
+            ],
+        )
+        _write_curation(
+            tmp_path,
+            [
+                _make_include("inventory", "main.items", "items"),
+                _make_include("crm", "main.users", "users"),
+            ],
+        )
+
+        cfg = load_config(config_file, validate=False)
+        assert len(cfg.tables) == 2
+        names = {t.name for t in cfg.tables}
+        assert names == {"inventory_items", "crm_users"}
+
+    def test_no_curation_no_tables_raises(self, tmp_path: Path):
+        from feather_etl.config import load_config
+
+        src_db = tmp_path / "source.duckdb"
+        src_db.touch()
+        config_file = _write_feather_yaml(
+            tmp_path,
+            [
+                {"type": "duckdb", "name": "erp", "path": str(src_db)},
+            ],
+        )
+
+        with pytest.raises(FileNotFoundError, match="curation.json"):
+            load_config(config_file)

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -6,32 +6,30 @@ from pathlib import Path
 
 import yaml
 
+from tests.helpers import make_curation_entry, write_curation
+
 
 class TestDedupConfig:
     def test_dedup_and_dedup_columns_mutually_exclusive(self, tmp_path: Path):
         """Validation rejects both dedup and dedup_columns set."""
-        from feather_etl.config import load_config
-        import pytest
+        from feather_etl.config import load_config, _validate
 
-        config = {
-            "sources": [{"type": "csv", "path": str(tmp_path)}],
-            "destination": {"path": str(tmp_path / "out.duckdb")},
-            "tables": [
-                {
-                    "name": "orders",
-                    "source_table": "orders.csv",
-                    "strategy": "full",
-                    "dedup": True,
-                    "dedup_columns": ["order_id"],
-                }
-            ],
-        }
-        # Create empty csv dir and file to avoid path validation error
         (tmp_path / "orders.csv").write_text("order_id,name\n1,A\n")
 
+        config = {
+            "sources": [{"type": "csv", "name": "csvs", "path": str(tmp_path)}],
+            "destination": {"path": str(tmp_path / "out.duckdb")},
+        }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
-        with pytest.raises(ValueError, match="dedup.*dedup_columns"):
-            load_config(tmp_path / "feather.yaml")
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
+        )
+        cfg = load_config(tmp_path / "feather.yaml", validate=False)
+        cfg.tables[0].dedup = True
+        cfg.tables[0].dedup_columns = ["order_id"]
+        errors = _validate(cfg)
+        assert any("dedup" in e and "dedup_columns" in e for e in errors)
 
 
 class TestDedupExtraction:
@@ -40,31 +38,26 @@ class TestDedupExtraction:
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_table
 
-        # Create CSV with duplicate rows
         csv_dir = tmp_path / "data"
         csv_dir.mkdir()
         (csv_dir / "orders.csv").write_text(
             "order_id,name,amount\n1,A,100\n2,B,200\n1,A,100\n3,C,300\n"
         )
         config = {
-            "sources": [{"type": "csv", "path": str(csv_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(csv_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "orders",
-                    "source_table": "orders.csv",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                    "dedup": True,
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
+        cfg.tables[0].dedup = True
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        assert result.rows_loaded == 3  # 4 rows → 3 after DISTINCT
+        assert result.rows_loaded == 3
 
     def test_dedup_columns_deduplicates_by_key(self, tmp_path: Path):
         """dedup_columns removes duplicates by specified columns."""
@@ -77,24 +70,20 @@ class TestDedupExtraction:
             "order_id,name,amount\n1,A,100\n2,B,200\n1,X,150\n3,C,300\n"
         )
         config = {
-            "sources": [{"type": "csv", "path": str(csv_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(csv_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "orders",
-                    "source_table": "orders.csv",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                    "dedup_columns": ["order_id"],
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
+        cfg.tables[0].dedup_columns = ["order_id"]
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        assert result.rows_loaded == 3  # 4 rows → 3 (dedup on order_id)
+        assert result.rows_loaded == 3
 
     def test_no_dedup_keeps_all_rows(self, tmp_path: Path):
         """Without dedup config, all rows are kept including duplicates."""
@@ -107,23 +96,19 @@ class TestDedupExtraction:
             "order_id,name,amount\n1,A,100\n2,B,200\n1,A,100\n3,C,300\n"
         )
         config = {
-            "sources": [{"type": "csv", "path": str(csv_dir)}],
+            "sources": [{"type": "csv", "name": "csvs", "path": str(csv_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "orders",
-                    "source_table": "orders.csv",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        assert result.rows_loaded == 4  # All rows kept
+        assert result.rows_loaded == 4
 
     def test_dedup_works_for_json_source(self, tmp_path: Path):
         """Dedup works for JSON sources via pipeline-level _apply_dedup."""
@@ -136,21 +121,17 @@ class TestDedupExtraction:
             '[{"id":1,"name":"A"},{"id":2,"name":"B"},{"id":1,"name":"A"}]'
         )
         config = {
-            "sources": [{"type": "json", "path": str(json_dir)}],
+            "sources": [{"type": "json", "name": "jsons", "path": str(json_dir)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "orders",
-                    "source_table": "orders.json",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                    "dedup": True,
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("jsons", "orders.json", "orders")],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
+        cfg.tables[0].dedup = True
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        assert result.rows_loaded == 2  # 3 rows → 2 after DISTINCT
+        assert result.rows_loaded == 2

--- a/tests/test_discover_expansion.py
+++ b/tests/test_discover_expansion.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from feather_etl.commands.discover import _expand_db_sources
+from feather_etl.sources.expand import expand_db_sources as _expand_db_sources
 from feather_etl.sources.postgres import PostgresSource
 
 

--- a/tests/test_dq.py
+++ b/tests/test_dq.py
@@ -8,6 +8,7 @@ import duckdb
 import pytest
 
 from feather_etl.dq import run_dq_checks
+from tests.helpers import make_curation_entry, write_curation
 
 
 @pytest.fixture
@@ -49,7 +50,7 @@ class TestNotNull:
         not_null = [r for r in results if r.check_type == "not_null"]
         assert len(not_null) == 1
         assert not_null[0].result == "fail"
-        assert "1" in not_null[0].details  # 1 NULL row
+        assert "1" in not_null[0].details
 
     def test_not_null_passes_on_clean_column(self, dq_db: Path):
         con = duckdb.connect(str(dq_db))
@@ -102,7 +103,6 @@ class TestUnique:
 
 class TestRowCount:
     def test_row_count_always_runs(self, dq_db: Path):
-        """row_count runs even with no quality_checks configured."""
         con = duckdb.connect(str(dq_db))
         results = run_dq_checks(con, "orders", "bronze.orders", None, "run_1")
         con.close()
@@ -125,7 +125,6 @@ class TestRowCount:
 
 class TestDuplicate:
     def test_config_driven_duplicate_detects_exact_rows(self, dq_db: Path):
-        """quality_checks: {duplicate: true} detects exact duplicate rows."""
         con = duckdb.connect(str(dq_db))
         results = run_dq_checks(
             con,
@@ -177,7 +176,6 @@ class TestDuplicate:
 
 class TestPipelineIntegration:
     def test_dq_results_stored_in_state(self, tmp_path: Path):
-        """DQ results are recorded in _dq_results after a run."""
         import shutil
         import yaml
 
@@ -189,36 +187,36 @@ class TestPipelineIntegration:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customers",
-                    "source_table": "erp.customers",
-                    "target_table": "bronze.customers",
-                    "strategy": "full",
-                    "quality_checks": {"not_null": ["name"]},
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.customers",
+                    "customers",
+                    primary_key=["customer_id"],
+                ),
+            ],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
+        cfg.tables[0].quality_checks = {"not_null": ["name"]}
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
 
-        # Check _dq_results has entries
         sm = StateManager(tmp_path / "feather_state.duckdb")
         con = sm._connect()
         rows = con.execute(
-            "SELECT * FROM _dq_results WHERE table_name = 'customers'"
+            "SELECT * FROM _dq_results WHERE table_name = 'src_customers'"
         ).fetchall()
         con.close()
-        # Should have at least row_count + not_null checks
         assert len(rows) >= 2
 
     def test_dq_failure_does_not_block_pipeline(self, tmp_path: Path):
-        """Pipeline continues even when DQ check fails."""
         import shutil
         import yaml
 
@@ -229,23 +227,23 @@ class TestPipelineIntegration:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customers",
-                    "source_table": "erp.customers",
-                    "target_table": "bronze.customers",
-                    "strategy": "full",
-                    # name column has some NULLs in sample_erp — force a check on id
-                    # that will pass, confirming pipeline completes
-                    "quality_checks": {"unique": ["name"]},
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.customers",
+                    "customers",
+                    primary_key=["customer_id"],
+                ),
+            ],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
+        cfg.tables[0].quality_checks = {"unique": ["name"]}
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
-        # Pipeline still succeeds even though unique check may fail
         assert result.status == "success"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,12 +8,13 @@ import yaml
 from typer.testing import CliRunner
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 runner = CliRunner()
 
 
 def test_full_onboarding_flow(tmp_path: Path, monkeypatch):
-    """init → validate → discover → setup → run → status → run again."""
+    """init -> validate -> discover -> setup -> run -> status -> run again."""
     from feather_etl.cli import app
 
     # --- 1. feather init ---
@@ -30,31 +31,20 @@ def test_full_onboarding_flow(tmp_path: Path, monkeypatch):
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(project_dir / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "sales_invoice",
-                "source_table": "icube.SALESINVOICE",
-                "target_table": "bronze.sales_invoice",
-                "strategy": "full",
-            },
-            {
-                "name": "customer_master",
-                "source_table": "icube.CUSTOMERMASTER",
-                "target_table": "bronze.customer_master",
-                "strategy": "full",
-            },
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-        ],
     }
     config_path = project_dir / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+
+    write_curation(
+        project_dir,
+        [
+            make_curation_entry("icube", "icube.SALESINVOICE", "sales_invoice"),
+            make_curation_entry("icube", "icube.CUSTOMERMASTER", "customer_master"),
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+        ],
+    )
 
     # --- 3. feather validate ---
     result = runner.invoke(app, ["validate", "--config", str(config_path)])
@@ -66,7 +56,6 @@ def test_full_onboarding_flow(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(project_dir)
     import feather_etl.commands.discover as discover_cmd
 
-    # Stub viewer runtime to avoid blocking e2e on the long-lived server/browser flow.
     monkeypatch.setattr(discover_cmd, "serve_and_open", lambda *args, **kwargs: None)
     result = runner.invoke(app, ["discover", "--config", str(config_path)])
     assert result.exit_code == 0, result.output
@@ -96,32 +85,38 @@ def test_full_onboarding_flow(tmp_path: Path, monkeypatch):
     data_db = str(project_dir / "feather_data.duckdb")
     con = duckdb.connect(data_db, read_only=True)
 
-    si_count = con.execute("SELECT COUNT(*) FROM bronze.sales_invoice").fetchone()[0]
+    si_count = con.execute(
+        "SELECT COUNT(*) FROM bronze.icube_sales_invoice"
+    ).fetchone()[0]
     assert si_count == 11676
 
-    cm_count = con.execute("SELECT COUNT(*) FROM bronze.customer_master").fetchone()[0]
+    cm_count = con.execute(
+        "SELECT COUNT(*) FROM bronze.icube_customer_master"
+    ).fetchone()[0]
     assert cm_count == 1339
 
-    ig_count = con.execute("SELECT COUNT(*) FROM bronze.inventory_group").fetchone()[0]
+    ig_count = con.execute(
+        "SELECT COUNT(*) FROM bronze.icube_inventory_group"
+    ).fetchone()[0]
     assert ig_count == 66
 
     # Verify ETL metadata columns
     row = con.execute(
-        "SELECT _etl_loaded_at, _etl_run_id FROM bronze.sales_invoice LIMIT 1"
+        "SELECT _etl_loaded_at, _etl_run_id FROM bronze.icube_sales_invoice LIMIT 1"
     ).fetchone()
-    assert row[0] is not None  # _etl_loaded_at
-    assert "sales_invoice" in row[1]  # _etl_run_id
+    assert row[0] is not None
+    assert "icube_sales_invoice" in row[1]
     con.close()
 
     # --- 7. feather status ---
     result = runner.invoke(app, ["status", "--config", str(config_path)])
     assert result.exit_code == 0, result.output
-    assert "sales_invoice" in result.output
-    assert "customer_master" in result.output
-    assert "inventory_group" in result.output
+    assert "icube_sales_invoice" in result.output
+    assert "icube_customer_master" in result.output
+    assert "icube_inventory_group" in result.output
     assert "success" in result.output
 
-    # --- 8. Second feather run (change detection → skip unchanged) ---
+    # --- 8. Second feather run (change detection -> skip unchanged) ---
     result = runner.invoke(app, ["run", "--config", str(config_path)])
     assert result.exit_code == 0, result.output
     assert "skipped (unchanged)" in result.output

--- a/tests/test_expand_db_sources.py
+++ b/tests/test_expand_db_sources.py
@@ -1,0 +1,57 @@
+"""Tests for the shared expand_db_sources utility."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+class TestExpandDbSources:
+    def test_file_sources_pass_through(self):
+        """File sources are returned unchanged."""
+        from feather_etl.sources.expand import expand_db_sources
+
+        mock_src = MagicMock()
+        mock_src.database = None
+        mock_src.databases = None
+        # Not a DatabaseSource subclass — simulate a FileSource
+        result = expand_db_sources([mock_src])
+        assert result == [mock_src]
+
+    def test_db_source_with_single_database_passes_through(self):
+        """DB source with database set is returned unchanged."""
+        from feather_etl.sources.expand import expand_db_sources
+        from feather_etl.sources.database_source import DatabaseSource
+
+        mock_src = MagicMock(spec=DatabaseSource)
+        mock_src.database = "mydb"
+        mock_src.databases = None
+        result = expand_db_sources([mock_src])
+        assert result == [mock_src]
+
+    def test_db_source_with_databases_list_expands(self):
+        """DB source with databases: [a, b] produces one child per db."""
+        from feather_etl.sources.expand import expand_db_sources
+        from feather_etl.sources.database_source import DatabaseSource
+
+        mock_src = MagicMock(spec=DatabaseSource)
+        mock_src.database = None
+        mock_src.databases = ["db_a", "db_b"]
+        mock_src.name = "test_server"
+        mock_src.type = "sqlserver"
+        mock_src.host = "localhost"
+        mock_src.port = 1433
+        mock_src.user = "sa"
+        mock_src.password = "pass"
+        mock_src._explicit_name = False
+
+        child_a = MagicMock(spec=DatabaseSource)
+        child_b = MagicMock(spec=DatabaseSource)
+        type(mock_src).from_yaml = MagicMock(side_effect=[child_a, child_b])
+
+        result = expand_db_sources([mock_src])
+        assert len(result) == 2
+        calls = type(mock_src).from_yaml.call_args_list
+        assert calls[0][0][0]["database"] == "db_a"
+        assert calls[0][0][0]["name"] == "test_server__db_a"
+        assert calls[1][0][0]["database"] == "db_b"
+        assert calls[1][0][0]["name"] == "test_server__db_b"

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -9,13 +9,13 @@ import pyarrow as pa
 from feather_etl.destinations.duckdb import DuckDBDestination
 from feather_etl.sources.file_source import FileSource
 from feather_etl.state import StateManager
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestBuildWhereClause:
     """Unit tests for FileSource._build_where_clause()."""
 
     def setup_method(self):
-        # FileSource needs a path but we only test the clause builder
         self.fs = FileSource(Path("/dummy"))
 
     def test_watermark_only(self):
@@ -60,19 +60,16 @@ class TestLoadIncremental:
 
     def test_incremental_inserts_new_rows(self, tmp_path: Path):
         dest = self._setup_dest(tmp_path)
-        # Initial full load
         data1 = _ts_arrow_table(["2025-01-01T00:00:00", "2025-01-02T00:00:00"], [1, 2])
         dest.load_full("bronze.sales", data1, "run_1")
 
-        # Incremental load with overlapping + new rows
         data2 = _ts_arrow_table(["2025-01-02T00:00:00", "2025-01-03T00:00:00"], [2, 3])
         rows = dest.load_incremental("bronze.sales", data2, "run_2", "modified_at")
         assert rows == 2
 
-        # Verify: row id=2 replaced (not duplicated), row id=3 added
         con = duckdb.connect(str(tmp_path / "dest.duckdb"), read_only=True)
         total = con.execute("SELECT COUNT(*) FROM bronze.sales").fetchone()[0]
-        assert total == 3  # ids 1, 2, 3
+        assert total == 3
         con.close()
 
     def test_incremental_zero_rows_is_noop(self, tmp_path: Path):
@@ -80,7 +77,6 @@ class TestLoadIncremental:
         data1 = _ts_arrow_table(["2025-01-01T00:00:00"], [1])
         dest.load_full("bronze.sales", data1, "run_1")
 
-        # Empty batch
         empty = pa.table(
             {
                 "id": pa.array([], type=pa.int64()),
@@ -91,7 +87,6 @@ class TestLoadIncremental:
         rows = dest.load_incremental("bronze.sales", empty, "run_2", "modified_at")
         assert rows == 0
 
-        # Original data untouched
         con = duckdb.connect(str(tmp_path / "dest.duckdb"), read_only=True)
         total = con.execute("SELECT COUNT(*) FROM bronze.sales").fetchone()[0]
         assert total == 1
@@ -99,14 +94,12 @@ class TestLoadIncremental:
 
     def test_incremental_deletes_by_timestamp(self, tmp_path: Path):
         dest = self._setup_dest(tmp_path)
-        # Load 3 rows
         data1 = _ts_arrow_table(
             ["2025-01-01T00:00:00", "2025-01-02T00:00:00", "2025-01-03T00:00:00"],
             [1, 2, 3],
         )
         dest.load_full("bronze.sales", data1, "run_1")
 
-        # Incremental: only rows >= 2025-01-02 should be deleted and replaced
         data2 = _ts_arrow_table(
             ["2025-01-02T00:00:00", "2025-01-03T00:00:00"], [20, 30]
         )
@@ -117,7 +110,6 @@ class TestLoadIncremental:
             r[0] for r in con.execute("SELECT id FROM bronze.sales").fetchall()
         )
         con.close()
-        # id=1 untouched, ids 2,3 replaced by 20,30
         assert ids == [1, 20, 30]
 
 
@@ -181,24 +173,29 @@ class TestPipelineIncremental:
         import yaml
         from feather_etl.config import load_config
 
-        table_def = {
-            "name": "orders",
-            "source_table": "erp.orders",
-            "target_table": "bronze.orders",
-            "strategy": "incremental",
-            "timestamp_column": "modified_at",
-        }
-        if filter:
-            table_def["filter"] = filter
-
         config_data = {
-            "sources": [{"type": "duckdb", "path": str(src_path)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(src_path)}],
             "destination": {"path": str(tmp_path / "dest.duckdb")},
-            "tables": [table_def],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config_data))
-        return load_config(config_file), config_file
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.orders",
+                    "orders",
+                    strategy="incremental",
+                    timestamp_column="modified_at",
+                    primary_key=["order_id"],
+                ),
+            ],
+        )
+        cfg = load_config(config_file)
+        if filter:
+            cfg.tables[0].filter = filter
+        return cfg, config_file
 
     def test_first_incremental_run_extracts_all(self, tmp_path: Path):
         from feather_etl.pipeline import run_table
@@ -210,9 +207,8 @@ class TestPipelineIncremental:
         assert result.status == "success"
         assert result.rows_loaded == 5
 
-        # Watermark should be set to MAX(modified_at)
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("orders")
+        wm = sm.read_watermark("src_orders")
         assert wm is not None
         assert wm["last_value"] is not None
         assert "2025-01-05" in str(wm["last_value"])
@@ -223,9 +219,7 @@ class TestPipelineIncremental:
         src_path = self._make_source_db(tmp_path)
         cfg, _ = self._make_config(tmp_path, src_path)
 
-        # First run
         run_table(cfg, cfg.tables[0], tmp_path)
-        # Second run — file unchanged so change detection should skip
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "skipped"
 
@@ -235,10 +229,8 @@ class TestPipelineIncremental:
         src_path = self._make_source_db(tmp_path)
         cfg, _ = self._make_config(tmp_path, src_path)
 
-        # First run
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Add new rows to source
         con = duckdb.connect(str(src_path))
         con.execute("""
             INSERT INTO erp.orders VALUES
@@ -247,64 +239,41 @@ class TestPipelineIncremental:
         """)
         con.close()
 
-        # Second run — should extract only new rows + overlap window
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
-        # With overlap_window_minutes=2, effective watermark = 2025-01-05 - 2min
-        # = 2025-01-04T23:58:00, so rows with modified_at >= that are extracted
-        # That means rows 5, 6, 7 (3 rows)
         assert result.rows_loaded == 3
 
-        # Watermark should advance to 2025-01-07
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("orders")
+        wm = sm.read_watermark("src_orders")
         assert "2025-01-07" in str(wm["last_value"])
 
     def test_run_after_incremental_no_new_rows_watermark_unchanged(
         self, tmp_path: Path
     ):
-        """PRD scenario 4: run after incremental, no new rows → watermark unchanged."""
         from feather_etl.pipeline import run_table
 
         src_path = self._make_source_db(tmp_path)
         cfg, _ = self._make_config(tmp_path, src_path)
 
-        # First run
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Add new rows
         con = duckdb.connect(str(src_path))
         con.execute("INSERT INTO erp.orders VALUES (6, 600.00, '2025-01-06 00:00:00')")
         con.close()
 
-        # Second run picks up new rows
         run_table(cfg, cfg.tables[0], tmp_path)
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm_after_second = sm.read_watermark("orders")
+        wm_after_second = sm.read_watermark("src_orders")
         watermark_after_second = wm_after_second["last_value"]
 
-        # Third run — file unchanged → skipped, watermark unchanged
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "skipped"
-        wm_after_third = sm.read_watermark("orders")
+        wm_after_third = sm.read_watermark("src_orders")
         assert wm_after_third["last_value"] == watermark_after_second
 
     def test_filter_excludes_matching_rows(self, tmp_path: Path):
-        """PRD scenario 5: filter field prevents matching rows from appearing."""
         from feather_etl.pipeline import run_table
 
-        src_path = self._make_source_db(tmp_path)
-        # Add a cancelled row
-        con = duckdb.connect(str(src_path))
-        con.execute("""
-            INSERT INTO erp.orders VALUES
-            (6, 600.00, '2025-01-06 00:00:00')
-        """)
-        # Update one row to cancelled status
-        con.execute("ALTER TABLE erp.orders ADD COLUMN status VARCHAR DEFAULT 'active'")
-        con.close()
-
-        # Recreate source with status column for cleaner test
         src_path2 = tmp_path / "source2.duckdb"
         con = duckdb.connect(str(src_path2))
         con.execute("CREATE SCHEMA erp")
@@ -328,12 +297,11 @@ class TestPipelineIncremental:
         result = run_table(cfg, cfg.tables[0], tmp_path)
 
         assert result.status == "success"
-        assert result.rows_loaded == 3  # only active rows
+        assert result.rows_loaded == 3
 
-        # Verify no cancelled rows in destination
         dest_con = duckdb.connect(str(tmp_path / "dest.duckdb"), read_only=True)
         cancelled = dest_con.execute(
-            "SELECT COUNT(*) FROM bronze.orders WHERE status = 'cancelled'"
+            "SELECT COUNT(*) FROM bronze.src_orders WHERE status = 'cancelled'"
         ).fetchone()[0]
         dest_con.close()
         assert cancelled == 0
@@ -346,45 +314,46 @@ class TestIncrementalWithFixture:
         import yaml
         from feather_etl.config import load_config
 
-        table_def = {
-            "name": "sales",
-            "source_table": "erp.sales",
-            "target_table": "bronze.sales",
-            "strategy": "incremental",
-            "timestamp_column": "modified_at",
-        }
-        if filter:
-            table_def["filter"] = filter
-
         config_data = {
-            "sources": [{"type": "duckdb", "path": str(src_path)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(src_path)}],
             "destination": {"path": str(tmp_path / "dest.duckdb")},
-            "tables": [table_def],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config_data))
-        return load_config(config_file), config_file
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.sales",
+                    "sales",
+                    strategy="incremental",
+                    timestamp_column="modified_at",
+                    primary_key=["sale_id"],
+                ),
+            ],
+        )
+        cfg = load_config(config_file)
+        if filter:
+            cfg.tables[0].filter = filter
+        return cfg, config_file
 
     def test_full_incremental_cycle_with_fixture(self, sample_erp_db, tmp_path: Path):
-        """Full PRD cycle: first run → no change → add rows → incremental."""
         from feather_etl.pipeline import run_table
 
         cfg, _ = self._make_config(tmp_path, sample_erp_db)
 
-        # 1. First run: all 10 rows extracted
         r1 = run_table(cfg, cfg.tables[0], tmp_path)
         assert r1.status == "success"
         assert r1.rows_loaded == 10
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm1 = sm.read_watermark("sales")
+        wm1 = sm.read_watermark("src_sales")
         assert "2025-01-10" in str(wm1["last_value"])
 
-        # 2. Second run: file unchanged → skipped
         r2 = run_table(cfg, cfg.tables[0], tmp_path)
         assert r2.status == "skipped"
 
-        # 3. Add new rows to source
         con = duckdb.connect(str(sample_erp_db))
         con.execute("""
             INSERT INTO erp.sales VALUES
@@ -393,28 +362,22 @@ class TestIncrementalWithFixture:
         """)
         con.close()
 
-        # 4. Third run: only new rows + overlap
         r3 = run_table(cfg, cfg.tables[0], tmp_path)
         assert r3.status == "success"
-        # effective wm = 2025-01-10 - 2min = 2025-01-09T23:58:00
-        # rows >= that: sale_id 10 (Jan 10), 11 (Jan 11), 12 (Jan 12) = 3 rows
         assert r3.rows_loaded == 3
 
-        wm3 = sm.read_watermark("sales")
+        wm3 = sm.read_watermark("src_sales")
         assert "2025-01-12" in str(wm3["last_value"])
 
-        # 5. Fourth run: file unchanged again → skipped
         r4 = run_table(cfg, cfg.tables[0], tmp_path)
         assert r4.status == "skipped"
 
-        # Verify total rows in destination: 10 original - 1 overlapping + 3 new = 12
         dest_con = duckdb.connect(str(tmp_path / "dest.duckdb"), read_only=True)
-        total = dest_con.execute("SELECT COUNT(*) FROM bronze.sales").fetchone()[0]
+        total = dest_con.execute("SELECT COUNT(*) FROM bronze.src_sales").fetchone()[0]
         dest_con.close()
         assert total == 12
 
     def test_filter_with_fixture(self, sample_erp_db, tmp_path: Path):
-        """erp.sales has 2 cancelled rows — filter should exclude them."""
         from feather_etl.pipeline import run_table
 
         cfg, _ = self._make_config(
@@ -423,30 +386,27 @@ class TestIncrementalWithFixture:
         result = run_table(cfg, cfg.tables[0], tmp_path)
 
         assert result.status == "success"
-        assert result.rows_loaded == 8  # 10 total - 2 cancelled
+        assert result.rows_loaded == 8
 
         dest_con = duckdb.connect(str(tmp_path / "dest.duckdb"), read_only=True)
         cancelled = dest_con.execute(
-            "SELECT COUNT(*) FROM bronze.sales WHERE status = 'cancelled'"
+            "SELECT COUNT(*) FROM bronze.src_sales WHERE status = 'cancelled'"
         ).fetchone()[0]
         dest_con.close()
         assert cancelled == 0
 
     def test_overlap_window_arithmetic(self, sample_erp_db, tmp_path: Path):
-        """Verify effective_watermark = stored_watermark - overlap_window_minutes."""
         from feather_etl.pipeline import run_table
 
         cfg, _ = self._make_config(tmp_path, sample_erp_db)
 
-        # First run
         run_table(cfg, cfg.tables[0], tmp_path)
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("sales")
+        wm = sm.read_watermark("src_sales")
         stored_wm = str(wm["last_value"])
         assert "2025-01-10" in stored_wm
 
-        # Add a row barely after the overlap window
         con = duckdb.connect(str(sample_erp_db))
         con.execute("""
             INSERT INTO erp.sales VALUES
@@ -454,8 +414,6 @@ class TestIncrementalWithFixture:
         """)
         con.close()
 
-        # Run again — effective watermark = 2025-01-10T00:00:00 - 2min = 2025-01-09T23:58:00
-        # Row at 2025-01-10 00:00:00 (sale_id=10) and 2025-01-10 00:05:00 (sale_id=11) should be extracted
         r2 = run_table(cfg, cfg.tables[0], tmp_path)
         assert r2.status == "success"
-        assert r2.rows_loaded == 2  # sale_id 10 and 11
+        assert r2.rows_loaded == 2

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,18 +7,10 @@ These tests use real DuckDB fixtures (no mocking) and cover:
   - Known bugs (documented with BUG-N labels matching the review report)
   - UX scenarios (error isolation, idempotency, path resolution, tables/ merge)
 
-When a bug is fixed the corresponding assertion should be INVERTED and the
-BUG label removed from the test name.
-
 Fixture layout
 --------------
-tests/fixtures/sample_erp.duckdb  — synthetic ERP (erp schema, 3 tables, 12 rows)
-    erp.orders    5 rows  — order_id, customer_id, order_date, total_amount, status, created_at
-    erp.customers 4 rows  — customer_id, name, email, city, credit_limit, created_at
-    erp.products  3 rows  — product_id, product_name, category, unit_price, stock_qty
-                            row 3: stock_qty IS NULL  (tests NULL pass-through)
-
-tests/fixtures/client.duckdb       — real Icube ERP data (icube schema, 6 tables)
+tests/fixtures/sample_erp.duckdb  -- synthetic ERP (erp schema, 3 tables, 12 rows)
+tests/fixtures/client.duckdb      -- real Icube ERP data (icube schema, 6 tables)
 """
 
 from __future__ import annotations
@@ -30,7 +22,10 @@ import duckdb
 import pytest
 import yaml
 
+from tests.helpers import make_curation_entry, write_curation
+
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -55,19 +50,25 @@ def client_db_copy(tmp_path) -> Path:
     return dst
 
 
-def _write_config(tmp_path: Path, source_db: Path, tables: list[dict]) -> Path:
+def _write_config(
+    tmp_path: Path,
+    source_db: Path,
+    curation_tables: list[dict],
+    source_name: str = "src",
+    source_type: str = "duckdb",
+) -> Path:
     cfg = {
-        "sources": [{"type": "duckdb", "path": str(source_db)}],
+        "sources": [{"type": source_type, "name": source_name, "path": str(source_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": tables,
     }
     p = tmp_path / "feather.yaml"
     p.write_text(yaml.dump(cfg, default_flow_style=False))
+    write_curation(tmp_path, curation_tables)
     return p
 
 
 # ---------------------------------------------------------------------------
-# sample_erp fixture — basic correctness
+# sample_erp fixture -- basic correctness
 # ---------------------------------------------------------------------------
 
 
@@ -96,7 +97,7 @@ class TestSampleErpFixture:
         con.close()
 
     def test_fixture_null_in_products(self, sample_erp_db):
-        """stock_qty is NULL for the 'Service Pack' row — tests NULL pass-through."""
+        """stock_qty is NULL for the 'Service Pack' row -- tests NULL pass-through."""
         con = duckdb.connect(str(sample_erp_db), read_only=True)
         row = con.execute(
             "SELECT stock_qty FROM erp.products WHERE product_name = 'Service Pack'"
@@ -115,24 +116,9 @@ class TestSampleErpFullPipeline:
             tmp_path,
             sample_erp_db,
             [
-                {
-                    "name": "orders",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                },
-                {
-                    "name": "customers",
-                    "source_table": "erp.customers",
-                    "target_table": "bronze.customers",
-                    "strategy": "full",
-                },
-                {
-                    "name": "products",
-                    "source_table": "erp.products",
-                    "target_table": "bronze.products",
-                    "strategy": "full",
-                },
+                make_curation_entry("src", "erp.orders", "orders"),
+                make_curation_entry("src", "erp.customers", "customers"),
+                make_curation_entry("src", "erp.products", "products"),
             ],
         )
 
@@ -143,7 +129,11 @@ class TestSampleErpFullPipeline:
         cfg = load_config(config)
         results = run_all(cfg, config)
         assert all(r.status == "success" for r in results)
-        assert {r.table_name for r in results} == {"orders", "customers", "products"}
+        assert {r.table_name for r in results} == {
+            "src_orders",
+            "src_customers",
+            "src_products",
+        }
 
     def test_row_counts_in_bronze(self, config):
         from feather_etl.config import load_config
@@ -153,9 +143,13 @@ class TestSampleErpFullPipeline:
         run_all(cfg, config)
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        assert con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0] == 5
-        assert con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0] == 4
-        assert con.execute("SELECT COUNT(*) FROM bronze.products").fetchone()[0] == 3
+        assert con.execute("SELECT COUNT(*) FROM bronze.src_orders").fetchone()[0] == 5
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.src_customers").fetchone()[0] == 4
+        )
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.src_products").fetchone()[0] == 3
+        )
         con.close()
 
     def test_null_passthrough(self, config):
@@ -168,10 +162,10 @@ class TestSampleErpFullPipeline:
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
         row = con.execute(
-            "SELECT stock_qty FROM bronze.products WHERE product_name = 'Service Pack'"
+            "SELECT stock_qty FROM bronze.src_products WHERE product_name = 'Service Pack'"
         ).fetchone()
         con.close()
-        assert row is not None, "Service Pack row missing from bronze.products"
+        assert row is not None, "Service Pack row missing from bronze.src_products"
         assert row[0] is None, f"Expected NULL stock_qty, got {row[0]!r}"
 
     def test_etl_metadata_columns_added(self, config):
@@ -186,7 +180,7 @@ class TestSampleErpFullPipeline:
             r[0]
             for r in con.execute(
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema = 'bronze' AND table_name = 'orders'"
+                "WHERE table_schema = 'bronze' AND table_name = 'src_orders'"
             ).fetchall()
         }
         con.close()
@@ -206,7 +200,7 @@ class TestSampleErpFullPipeline:
             r[0]
             for r in con.execute(
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema = 'bronze' AND table_name = 'orders'"
+                "WHERE table_schema = 'bronze' AND table_name = 'src_orders'"
             ).fetchall()
         }
         con.close()
@@ -230,7 +224,7 @@ class TestSampleErpFullPipeline:
         run_all(cfg, config)
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        assert con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0] == 5
+        assert con.execute("SELECT COUNT(*) FROM bronze.src_orders").fetchone()[0] == 5
         con.close()
 
     def test_state_records_runs(self, config):
@@ -248,34 +242,26 @@ class TestSampleErpFullPipeline:
         ).fetchall()
         con.close()
         run_map = {r[0]: (r[1], r[2]) for r in runs}
-        assert run_map["orders"] == ("success", 5)
-        assert run_map["customers"] == ("success", 4)
-        assert run_map["products"] == ("success", 3)
+        assert run_map["src_orders"] == ("success", 5)
+        assert run_map["src_customers"] == ("success", 4)
+        assert run_map["src_products"] == ("success", 3)
 
 
 # ---------------------------------------------------------------------------
-# Icube client fixture — edge cases
+# Icube client fixture -- edge cases
 # ---------------------------------------------------------------------------
 
 
 class TestClientFixtureEdgeCases:
     def test_salesinvoicemaster_column_with_space(self, client_db_copy, tmp_path):
-        """SALESINVOICEMASTER has a column called 'Round Off' (space in name).
-        Arrow must preserve it without error or renaming."""
+        """SALESINVOICEMASTER has a column called 'Round Off' (space in name)."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
         config = _write_config(
             tmp_path,
             client_db_copy,
-            [
-                {
-                    "name": "sim",
-                    "source_table": "icube.SALESINVOICEMASTER",
-                    "target_table": "bronze.sim",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "icube.SALESINVOICEMASTER", "sim")],
         )
         cfg = load_config(config)
         results = run_all(cfg, config)
@@ -286,7 +272,7 @@ class TestClientFixtureEdgeCases:
             r[0]
             for r in con.execute(
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema='bronze' AND table_name='sim'"
+                "WHERE table_schema='bronze' AND table_name='src_sim'"
             ).fetchall()
         }
         con.close()
@@ -300,14 +286,7 @@ class TestClientFixtureEdgeCases:
         config = _write_config(
             tmp_path,
             client_db_copy,
-            [
-                {
-                    "name": "invitem",
-                    "source_table": "icube.INVITEM",
-                    "target_table": "bronze.invitem",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "icube.INVITEM", "invitem")],
         )
         cfg = load_config(config)
         results = run_all(cfg, config)
@@ -319,45 +298,20 @@ class TestClientFixtureEdgeCases:
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
-        tables = [
-            {
-                "name": "sales_invoice",
-                "source_table": "icube.SALESINVOICE",
-                "target_table": "bronze.sales_invoice",
-                "strategy": "full",
-            },
-            {
-                "name": "customer_master",
-                "source_table": "icube.CUSTOMERMASTER",
-                "target_table": "bronze.customer_master",
-                "strategy": "full",
-            },
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-            {
-                "name": "inv_item",
-                "source_table": "icube.INVITEM",
-                "target_table": "bronze.inv_item",
-                "strategy": "full",
-            },
-            {
-                "name": "sales_invoice_master",
-                "source_table": "icube.SALESINVOICEMASTER",
-                "target_table": "bronze.sales_invoice_master",
-                "strategy": "full",
-            },
-            {
-                "name": "employee",
-                "source_table": "icube.EmployeeForm",
-                "target_table": "bronze.employee",
-                "strategy": "full",
-            },
-        ]
-        config = _write_config(tmp_path, client_db_copy, tables)
+        config = _write_config(
+            tmp_path,
+            client_db_copy,
+            [
+                make_curation_entry("src", "icube.SALESINVOICE", "sales_invoice"),
+                make_curation_entry("src", "icube.CUSTOMERMASTER", "customer_master"),
+                make_curation_entry("src", "icube.InventoryGroup", "inventory_group"),
+                make_curation_entry("src", "icube.INVITEM", "inv_item"),
+                make_curation_entry(
+                    "src", "icube.SALESINVOICEMASTER", "sales_invoice_master"
+                ),
+                make_curation_entry("src", "icube.EmployeeForm", "employee"),
+            ],
+        )
         cfg = load_config(config)
         results = run_all(cfg, config)
 
@@ -365,12 +319,12 @@ class TestClientFixtureEdgeCases:
             (r.table_name, r.error_message) for r in results if r.status != "success"
         ]
         row_map = {r.table_name: r.rows_loaded for r in results}
-        assert row_map["sales_invoice"] == 11676
-        assert row_map["customer_master"] == 1339
-        assert row_map["inventory_group"] == 66
-        assert row_map["inv_item"] == 1058
-        assert row_map["sales_invoice_master"] == 335
-        assert row_map["employee"] == 55
+        assert row_map["src_sales_invoice"] == 11676
+        assert row_map["src_customer_master"] == 1339
+        assert row_map["src_inventory_group"] == 66
+        assert row_map["src_inv_item"] == 1058
+        assert row_map["src_sales_invoice_master"] == 335
+        assert row_map["src_employee"] == 55
 
     def test_discover_icube_source(self, client_db_copy):
         """discover() returns all 6 Icube tables with column metadata."""
@@ -382,13 +336,12 @@ class TestClientFixtureEdgeCases:
         assert "icube.SALESINVOICE" in names
         assert "icube.CUSTOMERMASTER" in names
         assert len(schemas) == 6
-        # each schema has at least one column
         for s in schemas:
             assert len(s.columns) > 0, f"{s.name} has no columns"
 
 
 # ---------------------------------------------------------------------------
-# Error isolation — a bad table must not stop good tables
+# Error isolation -- a bad table must not stop good tables
 # ---------------------------------------------------------------------------
 
 
@@ -401,25 +354,15 @@ class TestErrorIsolation:
             tmp_path,
             sample_erp_db,
             [
-                {
-                    "name": "good",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.good",
-                    "strategy": "full",
-                },
-                {
-                    "name": "bad",
-                    "source_table": "erp.NOSUCH",
-                    "target_table": "bronze.bad",
-                    "strategy": "full",
-                },
+                make_curation_entry("src", "erp.orders", "good"),
+                make_curation_entry("src", "erp.NOSUCH", "bad"),
             ],
         )
         cfg = load_config(config)
         results = run_all(cfg, config)
 
-        good = next(r for r in results if r.table_name == "good")
-        bad = next(r for r in results if r.table_name == "bad")
+        good = next(r for r in results if r.table_name == "src_good")
+        bad = next(r for r in results if r.table_name == "src_bad")
         assert good.status == "success", "good table should succeed"
         assert bad.status == "failure", "bad table should fail"
         assert good.rows_loaded == 5
@@ -431,14 +374,7 @@ class TestErrorIsolation:
         config = _write_config(
             tmp_path,
             sample_erp_db,
-            [
-                {
-                    "name": "bad",
-                    "source_table": "erp.NOSUCH",
-                    "target_table": "bronze.bad",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "erp.NOSUCH", "bad")],
         )
         cfg = load_config(config)
         run_all(cfg, config)
@@ -446,7 +382,7 @@ class TestErrorIsolation:
         state_path = tmp_path / "feather_state.duckdb"
         con = duckdb.connect(str(state_path), read_only=True)
         row = con.execute(
-            "SELECT status, error_message FROM _runs WHERE table_name = 'bad'"
+            "SELECT status, error_message FROM _runs WHERE table_name = 'src_bad'"
         ).fetchone()
         con.close()
         assert row is not None
@@ -465,25 +401,15 @@ class TestErrorIsolation:
             tmp_path,
             sample_erp_db,
             [
-                {
-                    "name": "good",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                },
-                {
-                    "name": "bad",
-                    "source_table": "erp.NOSUCH",
-                    "target_table": "bronze.bad",
-                    "strategy": "full",
-                },
+                make_curation_entry("src", "erp.orders", "good"),
+                make_curation_entry("src", "erp.NOSUCH", "bad"),
             ],
         )
         cfg = load_config(config)
         run_all(cfg, config)
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        assert con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0] == 5
+        assert con.execute("SELECT COUNT(*) FROM bronze.src_good").fetchone()[0] == 5
         tables = {
             r[0]
             for r in con.execute(
@@ -491,115 +417,20 @@ class TestErrorIsolation:
             ).fetchall()
         }
         con.close()
-        assert "orders" in tables
-        assert "bad" not in tables  # failed table must not appear in bronze
+        assert "src_good" in tables
+        assert "src_bad" not in tables
 
 
 # ---------------------------------------------------------------------------
-# Tables/ directory merge
-# ---------------------------------------------------------------------------
-
-
-class TestTablesDirectoryMerge:
-    def test_tables_in_subdir_are_discovered(self, sample_erp_db, tmp_path):
-        """Tables defined in tables/*.yaml are merged with inline tables."""
-        from feather_etl.config import load_config
-
-        tables_dir = tmp_path / "tables"
-        tables_dir.mkdir()
-        (tables_dir / "sales.yaml").write_text(
-            yaml.dump(
-                {
-                    "tables": [
-                        {
-                            "name": "orders",
-                            "source_table": "erp.orders",
-                            "target_table": "bronze.orders",
-                            "strategy": "full",
-                        }
-                    ]
-                }
-            )
-        )
-        (tables_dir / "master.yaml").write_text(
-            yaml.dump(
-                {
-                    "tables": [
-                        {
-                            "name": "customers",
-                            "source_table": "erp.customers",
-                            "target_table": "bronze.customers",
-                            "strategy": "full",
-                        }
-                    ]
-                }
-            )
-        )
-        cfg_dict = {
-            "sources": [{"type": "duckdb", "path": str(sample_erp_db)}],
-            "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [],
-        }
-        config_path = tmp_path / "feather.yaml"
-        config_path.write_text(yaml.dump(cfg_dict))
-
-        cfg = load_config(config_path)
-        assert len(cfg.tables) == 2
-        names = {t.name for t in cfg.tables}
-        assert names == {"orders", "customers"}
-
-    def test_tables_dir_and_inline_combined(self, sample_erp_db, tmp_path):
-        """Inline tables + tables/*.yaml tables are all loaded."""
-        from feather_etl.config import load_config
-        from feather_etl.pipeline import run_all
-
-        tables_dir = tmp_path / "tables"
-        tables_dir.mkdir()
-        (tables_dir / "extra.yaml").write_text(
-            yaml.dump(
-                {
-                    "tables": [
-                        {
-                            "name": "products",
-                            "source_table": "erp.products",
-                            "target_table": "bronze.products",
-                            "strategy": "full",
-                        }
-                    ]
-                }
-            )
-        )
-        config = _write_config(
-            tmp_path,
-            sample_erp_db,
-            [
-                {
-                    "name": "orders",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.orders",
-                    "strategy": "full",
-                }
-            ],
-        )
-        cfg = load_config(config)
-        assert len(cfg.tables) == 2
-
-        results = run_all(cfg, config)
-        assert all(r.status == "success" for r in results)
-
-
-# ---------------------------------------------------------------------------
-# Validation guards — graduated from TestKnownBugs after fixes
+# Validation guards -- graduated from TestKnownBugs after fixes
 # ---------------------------------------------------------------------------
 
 
 class TestValidationGuards:
-    """Tests that validate catches invalid config before runtime.
-    Graduated from TestKnownBugs after BUG-2, BUG-3, BUG-7 fixes."""
+    """Tests that validate catches invalid config before runtime."""
 
     def test_csv_source_validates_with_valid_directory(self, tmp_path):
-        """CSV source type with a valid directory passes validation.
-        (Graduated from BUG-2: csv is now a registered source type.)"""
+        """CSV source type with a valid directory passes validation."""
         from feather_etl.config import load_config
 
         csv_dir = tmp_path / "csv_data"
@@ -609,18 +440,14 @@ class TestValidationGuards:
         config_path.write_text(
             yaml.dump(
                 {
-                    "sources": [{"type": "csv", "path": str(csv_dir)}],
+                    "sources": [{"type": "csv", "name": "csvs", "path": str(csv_dir)}],
                     "destination": {"path": str(tmp_path / "data.duckdb")},
-                    "tables": [
-                        {
-                            "name": "t",
-                            "source_table": "orders.csv",
-                            "target_table": "bronze.t",
-                            "strategy": "full",
-                        }
-                    ],
                 }
             )
+        )
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
         )
         cfg = load_config(config_path)
         assert cfg.sources[0].type == "csv"
@@ -635,18 +462,14 @@ class TestValidationGuards:
         config_path.write_text(
             yaml.dump(
                 {
-                    "sources": [{"type": "csv", "path": str(csv_file)}],
+                    "sources": [{"type": "csv", "name": "csvs", "path": str(csv_file)}],
                     "destination": {"path": str(tmp_path / "data.duckdb")},
-                    "tables": [
-                        {
-                            "name": "t",
-                            "source_table": "orders.csv",
-                            "target_table": "bronze.t",
-                            "strategy": "full",
-                        }
-                    ],
                 }
             )
+        )
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
         )
         with pytest.raises(ValueError, match="CSV source path must be a directory"):
             load_config(config_path)
@@ -659,25 +482,25 @@ class TestValidationGuards:
         config_path.write_text(
             yaml.dump(
                 {
-                    "sources": [{"type": "csv", "path": str(tmp_path / "no_such_dir")}],
-                    "destination": {"path": str(tmp_path / "data.duckdb")},
-                    "tables": [
+                    "sources": [
                         {
-                            "name": "t",
-                            "source_table": "orders.csv",
-                            "target_table": "bronze.t",
-                            "strategy": "full",
+                            "type": "csv",
+                            "name": "csvs",
+                            "path": str(tmp_path / "no_such_dir"),
                         }
                     ],
+                    "destination": {"path": str(tmp_path / "data.duckdb")},
                 }
             )
+        )
+        write_curation(
+            tmp_path,
+            [make_curation_entry("csvs", "orders.csv", "orders")],
         )
         with pytest.raises(ValueError, match="CSV source path must be a directory"):
             load_config(config_path)
 
     def test_missing_source_section_raises_valueerror(self, tmp_path):
-        """Missing 'source' section raises ValueError with a clear message.
-        (Graduated from BUG-3: previously raised raw KeyError.)"""
         from feather_etl.config import load_config
 
         config_path = tmp_path / "feather.yaml"
@@ -685,69 +508,39 @@ class TestValidationGuards:
             yaml.dump(
                 {
                     "destination": {"path": str(tmp_path / "data.duckdb")},
-                    "tables": [],
                 }
             )
         )
         with pytest.raises(ValueError, match="Missing required config section"):
             load_config(config_path)
 
-    def test_missing_strategy_field_raises_valueerror(self, sample_erp_db, tmp_path):
-        """Missing required table fields raise ValueError with field name.
-        (Graduated from BUG-3/BUG-4: previously raised raw KeyError.)"""
-        from feather_etl.config import load_config
-
-        cfg_dict = {
-            "sources": [{"type": "duckdb", "path": str(sample_erp_db)}],
-            "destination": {"path": str(tmp_path / "data.duckdb")},
-            "tables": [
-                {"name": "t", "source_table": "erp.orders", "target_table": "bronze.t"}
-            ],  # strategy missing
-        }
-        config_path = tmp_path / "feather.yaml"
-        config_path.write_text(yaml.dump(cfg_dict))
-        with pytest.raises(ValueError, match="missing required field"):
-            load_config(config_path)
-
     def test_target_table_requires_schema_prefix(self, sample_erp_db, tmp_path):
-        """target_table without schema prefix (e.g. 'my_table') is rejected.
-        (Graduated from BUG-7: previously passed validate, crashed at runtime.)"""
-        from feather_etl.config import load_config
+        """target_table without schema prefix is rejected (tested via _validate)."""
+        from feather_etl.config import load_config, _validate
 
         config = _write_config(
             tmp_path,
             sample_erp_db,
-            [
-                {
-                    "name": "t",
-                    "source_table": "erp.orders",
-                    "target_table": "no_schema_table",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "erp.orders", "orders")],
         )
-        with pytest.raises(ValueError, match="must include a schema prefix"):
-            load_config(config)
+        cfg = load_config(config, validate=False)
+        cfg.tables[0].target_table = "no_schema_table"
+        errors = _validate(cfg)
+        assert any("must include a schema prefix" in e for e in errors)
 
     def test_hyphenated_target_table_rejected(self, sample_erp_db, tmp_path):
-        """Hyphens in target_table are caught at validate time.
-        (Graduated from BUG-7: previously passed validate, crashed at runtime.)"""
-        from feather_etl.config import load_config
+        """Hyphens in target_table are caught at validate time (tested via _validate)."""
+        from feather_etl.config import load_config, _validate
 
         config = _write_config(
             tmp_path,
             sample_erp_db,
-            [
-                {
-                    "name": "my-table",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.my-table",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "erp.orders", "orders")],
         )
-        with pytest.raises(ValueError, match="invalid characters"):
-            load_config(config)
+        cfg = load_config(config, validate=False)
+        cfg.tables[0].target_table = "bronze.my-table"
+        errors = _validate(cfg)
+        assert any("invalid characters" in e for e in errors)
 
 
 # ---------------------------------------------------------------------------
@@ -756,10 +549,6 @@ class TestValidationGuards:
 
 
 class TestPipelineReturnsOnFailure:
-    """run_all() returns RunResult list (no exception) even when tables fail.
-    The CLI layer is responsible for exit codes.
-    (Graduated from BUG-5: CLI now exits 1 on failure.)"""
-
     def test_run_all_returns_results_on_total_failure(self, sample_erp_db, tmp_path):
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
@@ -767,14 +556,7 @@ class TestPipelineReturnsOnFailure:
         config = _write_config(
             tmp_path,
             sample_erp_db,
-            [
-                {
-                    "name": "bad",
-                    "source_table": "erp.NOSUCH",
-                    "target_table": "bronze.bad",
-                    "strategy": "full",
-                }
-            ],
+            [make_curation_entry("src", "erp.NOSUCH", "bad")],
         )
         cfg = load_config(config)
         results = run_all(cfg, config)
@@ -783,20 +565,15 @@ class TestPipelineReturnsOnFailure:
 
 
 # ---------------------------------------------------------------------------
-# Known bugs — remaining issues not yet fixed
+# Known bugs -- remaining issues not yet fixed
 # ---------------------------------------------------------------------------
 
 
 class TestKnownBugs:
-    # M-6 (strategy dispatch) — deferred to Slice 2
     def test_M6_incremental_strategy_silently_does_full_load(
         self, sample_erp_db, tmp_path
     ):
-        """M-6: strategy='incremental' (with timestamp_column) silently does a
-        full load instead of incremental extraction.  The validation gap (BUG-8:
-        incremental without timestamp_column) is now fixed.  This test documents
-        the remaining issue: strategy dispatch is not implemented yet.
-        After fix (Slice 2): run should perform actual incremental extraction."""
+        """M-6: strategy='incremental' silently does a full load."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
@@ -804,74 +581,63 @@ class TestKnownBugs:
             tmp_path,
             sample_erp_db,
             [
-                {
-                    "name": "orders",
-                    "source_table": "erp.orders",
-                    "target_table": "bronze.orders",
-                    "strategy": "incremental",
-                    "timestamp_column": "created_at",
-                }
+                make_curation_entry(
+                    "src",
+                    "erp.orders",
+                    "orders",
+                    strategy="incremental",
+                    timestamp_column="created_at",
+                    primary_key=["order_id"],
+                ),
             ],
         )
         cfg = load_config(config)
         results = run_all(cfg, config)
-        # Currently succeeds (full load performed silently) — strategy dispatch deferred
         assert results[0].status == "success"
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        count = con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0]
+        count = con.execute("SELECT COUNT(*) FROM bronze.src_orders").fetchone()[0]
         con.close()
-        assert count == 5  # all 5 rows loaded — full load, not incremental
+        assert count == 5
 
 
 # ---------------------------------------------------------------------------
-# CSV source — full pipeline integration
+# CSV source -- full pipeline integration
 # ---------------------------------------------------------------------------
 
 
-def _write_csv_config(tmp_path: Path, csv_dir: Path, tables: list[dict]) -> Path:
+def _write_csv_config(
+    tmp_path: Path, csv_dir: Path, curation_tables: list[dict]
+) -> Path:
     cfg = {
-        "sources": [{"type": "csv", "path": str(csv_dir)}],
+        "sources": [{"type": "csv", "name": "csvs", "path": str(csv_dir)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": tables,
     }
     p = tmp_path / "feather.yaml"
     p.write_text(yaml.dump(cfg, default_flow_style=False))
+    write_curation(tmp_path, curation_tables)
     return p
 
 
-def _write_sqlite_config(tmp_path: Path, sqlite_path: Path, tables: list[dict]) -> Path:
+def _write_sqlite_config(
+    tmp_path: Path, sqlite_path: Path, curation_tables: list[dict]
+) -> Path:
     cfg = {
-        "sources": [{"type": "sqlite", "path": str(sqlite_path)}],
+        "sources": [{"type": "sqlite", "name": "sqlitedb", "path": str(sqlite_path)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": tables,
     }
     p = tmp_path / "feather.yaml"
     p.write_text(yaml.dump(cfg, default_flow_style=False))
+    write_curation(tmp_path, curation_tables)
     return p
 
 
 class TestCsvFullPipeline:
     """Full pipeline run using CSV source."""
 
-    CSV_TABLES = [
-        {
-            "name": "orders",
-            "source_table": "orders.csv",
-            "target_table": "bronze.orders",
-            "strategy": "full",
-        },
-        {
-            "name": "customers",
-            "source_table": "customers.csv",
-            "target_table": "bronze.customers",
-            "strategy": "full",
-        },
-        {
-            "name": "products",
-            "source_table": "products.csv",
-            "target_table": "bronze.products",
-            "strategy": "full",
-        },
+    CSV_CURATION = [
+        make_curation_entry("csvs", "orders.csv", "orders"),
+        make_curation_entry("csvs", "customers.csv", "customers"),
+        make_curation_entry("csvs", "products.csv", "products"),
     ]
 
     @pytest.fixture
@@ -883,7 +649,7 @@ class TestCsvFullPipeline:
 
     @pytest.fixture
     def config(self, csv_data_dir, tmp_path) -> Path:
-        return _write_csv_config(tmp_path, csv_data_dir, self.CSV_TABLES)
+        return _write_csv_config(tmp_path, csv_data_dir, self.CSV_CURATION)
 
     def test_run_all_succeeds(self, config):
         from feather_etl.config import load_config
@@ -892,7 +658,11 @@ class TestCsvFullPipeline:
         cfg = load_config(config)
         results = run_all(cfg, config)
         assert all(r.status == "success" for r in results)
-        assert {r.table_name for r in results} == {"orders", "customers", "products"}
+        assert {r.table_name for r in results} == {
+            "csvs_orders",
+            "csvs_customers",
+            "csvs_products",
+        }
 
     def test_row_counts_in_bronze(self, config):
         from feather_etl.config import load_config
@@ -902,9 +672,13 @@ class TestCsvFullPipeline:
         run_all(cfg, config)
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        assert con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0] == 5
-        assert con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0] == 4
-        assert con.execute("SELECT COUNT(*) FROM bronze.products").fetchone()[0] == 3
+        assert con.execute("SELECT COUNT(*) FROM bronze.csvs_orders").fetchone()[0] == 5
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.csvs_customers").fetchone()[0] == 4
+        )
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.csvs_products").fetchone()[0] == 3
+        )
         con.close()
 
     def test_null_passthrough(self, config):
@@ -916,7 +690,7 @@ class TestCsvFullPipeline:
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
         row = con.execute(
-            "SELECT stock_qty FROM bronze.products WHERE product_name = 'Service Pack'"
+            "SELECT stock_qty FROM bronze.csvs_products WHERE product_name = 'Service Pack'"
         ).fetchone()
         con.close()
         assert row is not None
@@ -934,7 +708,7 @@ class TestCsvFullPipeline:
             r[0]
             for r in con.execute(
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema = 'bronze' AND table_name = 'orders'"
+                "WHERE table_schema = 'bronze' AND table_name = 'csvs_orders'"
             ).fetchall()
         }
         con.close()
@@ -943,32 +717,17 @@ class TestCsvFullPipeline:
 
 
 # ---------------------------------------------------------------------------
-# SQLite source — full pipeline integration
+# SQLite source -- full pipeline integration
 # ---------------------------------------------------------------------------
 
 
 class TestSqliteFullPipeline:
     """Full pipeline run using SQLite source."""
 
-    SQLITE_TABLES = [
-        {
-            "name": "orders",
-            "source_table": "orders",
-            "target_table": "bronze.orders",
-            "strategy": "full",
-        },
-        {
-            "name": "customers",
-            "source_table": "customers",
-            "target_table": "bronze.customers",
-            "strategy": "full",
-        },
-        {
-            "name": "products",
-            "source_table": "products",
-            "target_table": "bronze.products",
-            "strategy": "full",
-        },
+    SQLITE_CURATION = [
+        make_curation_entry("sqlitedb", "orders", "orders"),
+        make_curation_entry("sqlitedb", "customers", "customers"),
+        make_curation_entry("sqlitedb", "products", "products"),
     ]
 
     @pytest.fixture
@@ -980,7 +739,7 @@ class TestSqliteFullPipeline:
 
     @pytest.fixture
     def config(self, sqlite_db, tmp_path) -> Path:
-        return _write_sqlite_config(tmp_path, sqlite_db, self.SQLITE_TABLES)
+        return _write_sqlite_config(tmp_path, sqlite_db, self.SQLITE_CURATION)
 
     def test_run_all_succeeds(self, config):
         from feather_etl.config import load_config
@@ -989,7 +748,11 @@ class TestSqliteFullPipeline:
         cfg = load_config(config)
         results = run_all(cfg, config)
         assert all(r.status == "success" for r in results)
-        assert {r.table_name for r in results} == {"orders", "customers", "products"}
+        assert {r.table_name for r in results} == {
+            "sqlitedb_orders",
+            "sqlitedb_customers",
+            "sqlitedb_products",
+        }
 
     def test_row_counts_in_bronze(self, config):
         from feather_etl.config import load_config
@@ -999,9 +762,18 @@ class TestSqliteFullPipeline:
         run_all(cfg, config)
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
-        assert con.execute("SELECT COUNT(*) FROM bronze.orders").fetchone()[0] == 5
-        assert con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0] == 4
-        assert con.execute("SELECT COUNT(*) FROM bronze.products").fetchone()[0] == 3
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.sqlitedb_orders").fetchone()[0]
+            == 5
+        )
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.sqlitedb_customers").fetchone()[0]
+            == 4
+        )
+        assert (
+            con.execute("SELECT COUNT(*) FROM bronze.sqlitedb_products").fetchone()[0]
+            == 3
+        )
         con.close()
 
     def test_null_passthrough(self, config):
@@ -1013,7 +785,7 @@ class TestSqliteFullPipeline:
 
         con = duckdb.connect(str(cfg.destination.path), read_only=True)
         row = con.execute(
-            "SELECT stock_qty FROM bronze.products WHERE product_name = 'Service Pack'"
+            "SELECT stock_qty FROM bronze.sqlitedb_products WHERE product_name = 'Service Pack'"
         ).fetchone()
         con.close()
         assert row is not None
@@ -1031,7 +803,7 @@ class TestSqliteFullPipeline:
             r[0]
             for r in con.execute(
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema = 'bronze' AND table_name = 'orders'"
+                "WHERE table_schema = 'bronze' AND table_name = 'sqlitedb_orders'"
             ).fetchall()
         }
         con.close()

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -1,4 +1,4 @@
-"""Tests for JSONL structured logging (V18 — Task 6) and --json output (Tasks 7-8)."""
+"""Tests for JSONL structured logging (V18 -- Task 6) and --json output (Tasks 7-8)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from typer.testing import CliRunner
 
 from tests.commands.conftest import cli_config
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestJsonlLogging:
@@ -22,19 +23,15 @@ class TestJsonlLogging:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "inventory_group",
-                    "source_table": "icube.InventoryGroup",
-                    "target_table": "bronze.inventory_group",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("icube", "icube.InventoryGroup", "inventory_group")],
+        )
         cfg = load_config(config_file)
 
         run_all(cfg, config_file)
@@ -49,19 +46,15 @@ class TestJsonlLogging:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "inventory_group",
-                    "source_table": "icube.InventoryGroup",
-                    "target_table": "bronze.inventory_group",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("icube", "icube.InventoryGroup", "inventory_group")],
+        )
         cfg = load_config(config_file)
 
         run_all(cfg, config_file)
@@ -82,19 +75,15 @@ class TestJsonlLogging:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "inventory_group",
-                    "source_table": "icube.InventoryGroup",
-                    "target_table": "bronze.inventory_group",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("icube", "icube.InventoryGroup", "inventory_group")],
+        )
         cfg = load_config(config_file)
 
         run_all(cfg, config_file)
@@ -157,5 +146,4 @@ class TestCliJsonFlag:
         config_file = cli_config(tmp_path)
         result = runner.invoke(app, ["validate", "--config", str(config_file)])
         assert result.exit_code == 0
-        # Should have human text, not JSON
         assert "Config valid" in result.output

--- a/tests/test_mode.py
+++ b/tests/test_mode.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 # --- Task 1: Config tests ---
@@ -20,16 +21,8 @@ def _write_config(tmp_path: Path, mode: str | None = None, **overrides) -> Path:
     shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", src_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(tmp_path / "output.duckdb")},
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-                "target_table": "bronze.customers",
-            },
-        ],
     }
     if mode is not None:
         config["mode"] = mode
@@ -37,6 +30,10 @@ def _write_config(tmp_path: Path, mode: str | None = None, **overrides) -> Path:
 
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
     return config_path
 
 
@@ -105,7 +102,9 @@ def test_config_row_limit_defaults_to_none(tmp_path):
 
 
 def test_config_empty_target_table_valid_with_mode(tmp_path):
-    """Tables without target_table are valid — mode derives the target."""
+    """Tables without target_table are valid -- mode derives the target.
+    With curation, target_table is always set to bronze.<name>, so
+    we test mode-derived target through pipeline behavior instead."""
     import shutil
 
     from feather_etl.config import load_config
@@ -114,22 +113,19 @@ def test_config_empty_target_table_valid_with_mode(tmp_path):
     shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", src_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(tmp_path / "output.duckdb")},
         "mode": "dev",
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-                # NO target_table — mode derives it
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     cfg = load_config(config_path)
+    # Curation leaves target_table empty — mode derives it at runtime
     assert cfg.tables[0].target_table == ""
 
 
@@ -151,27 +147,27 @@ def _run_pipeline(
     src_db = tmp_path / "sample_erp.duckdb"
     shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", src_db)
 
-    table_def: dict = {
-        "name": "customers",
-        "source_table": "erp.customers",
-        "strategy": "full",
-    }
-    if target_table is not None:
-        table_def["target_table"] = target_table
-    if column_map is not None:
-        table_def["column_map"] = column_map
-
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
         "mode": mode,
-        "tables": [table_def],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     cfg = load_config(config_path)
+
+    # Apply overrides that curation doesn't handle
+    if column_map is not None:
+        cfg.tables[0].column_map = column_map
+    if target_table is not None:
+        cfg.tables[0].target_table = target_table
+
     results = run_all(cfg, config_path)
     return cfg, results, dest_path
 
@@ -182,7 +178,7 @@ def test_dev_extracts_to_bronze(tmp_path):
 
     assert results[0].status == "success"
     con = duckdb.connect(str(dest_path))
-    count = con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+    count = con.execute("SELECT COUNT(*) FROM bronze.erp_customers").fetchone()[0]
     con.close()
     assert count > 0
 
@@ -193,7 +189,7 @@ def test_prod_extracts_to_silver(tmp_path):
 
     assert results[0].status == "success"
     con = duckdb.connect(str(dest_path))
-    count = con.execute("SELECT COUNT(*) FROM silver.customers").fetchone()[0]
+    count = con.execute("SELECT COUNT(*) FROM silver.erp_customers").fetchone()[0]
     con.close()
     assert count > 0
 
@@ -212,21 +208,20 @@ def test_prod_with_column_map(tmp_path):
         row[0]
         for row in con.execute(
             "SELECT column_name FROM information_schema.columns "
-            "WHERE table_schema='silver' AND table_name='customers' "
+            "WHERE table_schema='silver' AND table_name='erp_customers' "
             "ORDER BY ordinal_position"
         ).fetchall()
     ]
     con.close()
 
-    # Should have renamed columns + ETL metadata
     assert "cust_id" in cols
     assert "cust_name" in cols
-    assert "customer_id" not in cols  # source name should be renamed
-    assert "email" not in cols  # unmapped columns excluded
+    assert "customer_id" not in cols
+    assert "email" not in cols
 
 
 def test_dev_with_column_map_ignores_it(tmp_path):
-    """Dev mode ignores column_map — extracts all columns to bronze."""
+    """Dev mode ignores column_map -- extracts all columns to bronze."""
     _, results, dest_path = _run_pipeline(
         tmp_path,
         mode="dev",
@@ -239,29 +234,28 @@ def test_dev_with_column_map_ignores_it(tmp_path):
         row[0]
         for row in con.execute(
             "SELECT column_name FROM information_schema.columns "
-            "WHERE table_schema='bronze' AND table_name='customers' "
+            "WHERE table_schema='bronze' AND table_name='erp_customers' "
             "ORDER BY ordinal_position"
         ).fetchall()
     ]
     con.close()
 
-    # All original source columns present (not renamed)
     assert "customer_id" in cols
     assert "name" in cols
-    assert "email" in cols  # all columns present
+    assert "email" in cols
 
 
 def test_explicit_target_overrides_mode(tmp_path):
-    """Explicit target_table in YAML overrides mode-derived target."""
+    """Explicit target_table overrides mode-derived target."""
     _, results, dest_path = _run_pipeline(
         tmp_path,
         mode="prod",
-        target_table="bronze.customers",  # explicit override
+        target_table="bronze.erp_customers",
     )
 
     assert results[0].status == "success"
     con = duckdb.connect(str(dest_path))
-    count = con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+    count = con.execute("SELECT COUNT(*) FROM bronze.erp_customers").fetchone()[0]
     con.close()
     assert count > 0
 
@@ -279,20 +273,17 @@ def _run_with_transforms(tmp_path: Path, mode: str) -> Path:
     src_db = tmp_path / "sample_erp.duckdb"
     shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", src_db)
 
-    # Create transform dirs + files
     silver_dir = tmp_path / "transforms" / "silver"
     gold_dir = tmp_path / "transforms" / "gold"
     silver_dir.mkdir(parents=True)
     gold_dir.mkdir(parents=True)
 
-    # Silver view: rename columns from bronze
     (silver_dir / "customers_clean.sql").write_text(
-        "-- depends_on: bronze.customers\n"
+        "-- depends_on: bronze.erp_customers\n"
         "SELECT customer_id, name AS customer_name, city\n"
-        "FROM bronze.customers\n"
+        "FROM bronze.erp_customers\n"
     )
 
-    # Gold materialized table
     (gold_dir / "customer_summary.sql").write_text(
         "-- depends_on: silver.customers_clean\n"
         "-- materialized: true\n"
@@ -303,22 +294,20 @@ def _run_with_transforms(tmp_path: Path, mode: str) -> Path:
 
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
         "mode": mode,
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-                "target_table": "bronze.customers",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     cfg = load_config(config_path)
+    # Force target to bronze so transforms can reference it consistently
+    cfg.tables[0].target_table = "bronze.erp_customers"
     run_all(cfg, config_path)
     return dest_path
 
@@ -368,21 +357,17 @@ def test_test_mode_with_row_limit(tmp_path):
 
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
         "mode": "test",
         "defaults": {"row_limit": 2},
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-                "target_table": "bronze.customers",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     cfg = load_config(config_path)
     results = run_all(cfg, config_path)
@@ -391,7 +376,7 @@ def test_test_mode_with_row_limit(tmp_path):
     assert results[0].rows_loaded <= 2
 
     con = duckdb.connect(str(dest_path))
-    count = con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+    count = con.execute("SELECT COUNT(*) FROM bronze.erp_customers").fetchone()[0]
     con.close()
     assert count <= 2
 
@@ -408,27 +393,22 @@ def test_dev_mode_ignores_row_limit(tmp_path):
 
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
         "mode": "dev",
         "defaults": {"row_limit": 2},
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-                "target_table": "bronze.customers",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     cfg = load_config(config_path)
     results = run_all(cfg, config_path)
 
     assert results[0].status == "success"
-    # sample_erp has 4 customers — dev should get all of them
     assert results[0].rows_loaded > 2
 
 
@@ -438,13 +418,13 @@ def test_dev_mode_ignores_row_limit(tmp_path):
 def test_cli_mode_overrides_yaml(tmp_path):
     """--mode prod CLI flag overrides mode: dev in YAML."""
     _, results, dest_path = _run_pipeline(tmp_path, mode="dev")
-    # Dev mode: data in bronze
     con = duckdb.connect(str(dest_path))
-    bronze_count = con.execute("SELECT COUNT(*) FROM bronze.customers").fetchone()[0]
+    bronze_count = con.execute("SELECT COUNT(*) FROM bronze.erp_customers").fetchone()[
+        0
+    ]
     con.close()
     assert bronze_count > 0
 
-    # Now re-run with mode_override=prod — should go to silver
     import shutil
 
     from feather_etl.config import load_config
@@ -457,32 +437,31 @@ def test_cli_mode_overrides_yaml(tmp_path):
 
     dest_path2 = tmp2 / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path2)},
-        "mode": "dev",  # YAML says dev
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-            },
-        ],
+        "mode": "dev",
     }
     config_path = tmp2 / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp2,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
-    cfg = load_config(config_path, mode_override="prod")  # CLI says prod
+    cfg = load_config(config_path, mode_override="prod")
     assert cfg.mode == "prod"
     run_all(cfg, config_path)
 
     con = duckdb.connect(str(dest_path2))
-    silver_count = con.execute("SELECT COUNT(*) FROM silver.customers").fetchone()[0]
+    silver_count = con.execute("SELECT COUNT(*) FROM silver.erp_customers").fetchone()[
+        0
+    ]
     con.close()
     assert silver_count > 0
 
 
 def test_cli_mode_flag_via_runner(tmp_path):
-    """--mode prod CLI flag exercises the actual Typer CLI path (Truth #7)."""
+    """--mode prod CLI flag exercises the actual Typer CLI path."""
     import shutil
 
     from typer.testing import CliRunner
@@ -494,27 +473,25 @@ def test_cli_mode_flag_via_runner(tmp_path):
 
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
-        "mode": "dev",  # YAML says dev
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-            },
-        ],
+        "mode": "dev",
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     runner = CliRunner()
     result = runner.invoke(app, ["run", "--config", str(config_path), "--mode", "prod"])
     assert result.exit_code == 0
 
-    # --mode prod should land data in silver, not bronze
     con = duckdb.connect(str(dest_path))
-    silver_count = con.execute("SELECT COUNT(*) FROM silver.customers").fetchone()[0]
+    silver_count = con.execute("SELECT COUNT(*) FROM silver.erp_customers").fetchone()[
+        0
+    ]
     con.close()
     assert silver_count > 0
 
@@ -531,19 +508,16 @@ def test_env_var_overrides_yaml(tmp_path, monkeypatch):
 
     dest_path = tmp_path / "output.duckdb"
     config = {
-        "sources": [{"type": "duckdb", "path": str(src_db)}],
+        "sources": [{"type": "duckdb", "name": "erp", "path": str(src_db)}],
         "destination": {"path": str(dest_path)},
-        "mode": "dev",  # YAML says dev
-        "tables": [
-            {
-                "name": "customers",
-                "source_table": "erp.customers",
-                "strategy": "full",
-            },
-        ],
+        "mode": "dev",
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "erp.customers", "customers")],
+    )
 
     monkeypatch.setenv("FEATHER_MODE", "prod")
     cfg = load_config(config_path)
@@ -551,6 +525,8 @@ def test_env_var_overrides_yaml(tmp_path, monkeypatch):
     run_all(cfg, config_path)
 
     con = duckdb.connect(str(dest_path))
-    silver_count = con.execute("SELECT COUNT(*) FROM silver.customers").fetchone()[0]
+    silver_count = con.execute("SELECT COUNT(*) FROM silver.erp_customers").fetchone()[
+        0
+    ]
     con.close()
     assert silver_count > 0

--- a/tests/test_multi_source_e2e.py
+++ b/tests/test_multi_source_e2e.py
@@ -1,0 +1,207 @@
+"""End-to-end test: multi-source extraction via curation.json."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import duckdb
+import yaml
+
+from feather_etl.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _setup_multi_source_project(tmp_path: Path) -> Path:
+    """Create a project with 2 DuckDB sources + curation.json."""
+    # Source A: ERP with orders and customers
+    # Use distinct file names to avoid DuckDB catalog/schema name collision
+    # (e.g. erp.duckdb + CREATE SCHEMA erp is ambiguous in newer DuckDB).
+    src_a = tmp_path / "erp_source.duckdb"
+    con = duckdb.connect(str(src_a))
+    con.execute("CREATE SCHEMA erp")
+    con.execute("CREATE TABLE erp.orders (id INT, amount DOUBLE)")
+    con.execute("INSERT INTO erp.orders VALUES (1, 100.0), (2, 200.0), (3, 300.0)")
+    con.execute("CREATE TABLE erp.customers (id INT, name VARCHAR)")
+    con.execute("INSERT INTO erp.customers VALUES (1, 'Alice'), (2, 'Bob')")
+    con.close()
+
+    # Source B: inventory with products
+    src_b = tmp_path / "inventory_source.duckdb"
+    con = duckdb.connect(str(src_b))
+    con.execute("CREATE SCHEMA inv")
+    con.execute("CREATE TABLE inv.products (id INT, sku VARCHAR, price DOUBLE)")
+    con.execute(
+        "INSERT INTO inv.products VALUES (1, 'SKU001', 9.99), (2, 'SKU002', 19.99)"
+    )
+    con.close()
+
+    # feather.yaml — two sources, no tables
+    config = {
+        "sources": [
+            {"type": "duckdb", "name": "erp", "path": str(src_a)},
+            {"type": "duckdb", "name": "inventory", "path": str(src_b)},
+        ],
+        "destination": {"path": str(tmp_path / "feather_data.duckdb")},
+    }
+    config_file = tmp_path / "feather.yaml"
+    config_file.write_text(yaml.dump(config, default_flow_style=False))
+
+    # discovery/curation.json — 3 include entries across 2 sources
+    discovery_dir = tmp_path / "discovery"
+    discovery_dir.mkdir()
+    curation = {
+        "version": 2,
+        "updated_at": "2026-04-18T00:00:00Z",
+        "notes": "test",
+        "source_systems": {},
+        "policies": {"data_quality": {"default": "flag", "escalations": []}},
+        "tables": [
+            {
+                "source_db": "erp",
+                "source_table": "erp.orders",
+                "decision": "include",
+                "table_type": "fact",
+                "group": "erp",
+                "alias": "orders",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": "one row per order",
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "erp",
+                "source_table": "erp.customers",
+                "decision": "include",
+                "table_type": "dimension",
+                "group": "erp",
+                "alias": "customers",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "inventory",
+                "source_table": "inv.products",
+                "decision": "include",
+                "table_type": "dimension",
+                "group": "inventory",
+                "alias": "products",
+                "classification_notes": None,
+                "strategy": "full",
+                "primary_key": ["id"],
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "test",
+            },
+            {
+                "source_db": "erp",
+                "source_table": "erp.audit_log",
+                "decision": "exclude",
+                "table_type": "audit",
+                "group": "erp",
+                "alias": None,
+                "classification_notes": None,
+                "strategy": None,
+                "primary_key": None,
+                "timestamp": None,
+                "grain": None,
+                "scd": None,
+                "mapping": None,
+                "dq_policy": None,
+                "load_contract": None,
+                "reason": "not needed",
+            },
+        ],
+    }
+    (discovery_dir / "curation.json").write_text(json.dumps(curation))
+
+    return config_file
+
+
+class TestMultiSourceE2E:
+    def test_feather_run_extracts_from_multiple_sources(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """feather run extracts tables from 2 DuckDB sources via curation.json."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+
+        result = runner.invoke(app, ["run", "--config", str(config_file)])
+        assert result.exit_code == 0, f"stdout: {result.stdout}"
+
+        # Verify data landed in bronze
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        tables = [
+            row[0]
+            for row in dest.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
+            ).fetchall()
+        ]
+        dest.close()
+
+        assert "erp_orders" in tables
+        assert "erp_customers" in tables
+        assert "inventory_products" in tables
+        assert len(tables) == 3  # excluded table not present
+
+    def test_row_counts_correct(self, tmp_path: Path, monkeypatch):
+        """Verify row counts match source data."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+        runner.invoke(app, ["run", "--config", str(config_file)])
+
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        orders = dest.execute("SELECT COUNT(*) FROM bronze.erp_orders").fetchone()[0]
+        customers = dest.execute(
+            "SELECT COUNT(*) FROM bronze.erp_customers"
+        ).fetchone()[0]
+        products = dest.execute(
+            "SELECT COUNT(*) FROM bronze.inventory_products"
+        ).fetchone()[0]
+        dest.close()
+
+        assert orders == 3
+        assert customers == 2
+        assert products == 2
+
+    def test_table_filter_works_with_bronze_name(self, tmp_path: Path, monkeypatch):
+        """--table flag filters by curation-derived bronze name."""
+        monkeypatch.chdir(tmp_path)
+        config_file = _setup_multi_source_project(tmp_path)
+
+        result = runner.invoke(
+            app, ["run", "--config", str(config_file), "--table", "erp_orders"]
+        )
+        assert result.exit_code == 0
+
+        dest = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
+        tables = [
+            row[0]
+            for row in dest.execute(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
+            ).fetchall()
+        ]
+        dest.close()
+
+        assert "erp_orders" in tables
+        assert "erp_customers" not in tables  # not extracted — filtered out

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 @pytest.fixture
@@ -18,25 +19,18 @@ def setup_env(tmp_path: Path) -> tuple[Path, Path]:
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
 
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            },
-            {
-                "name": "customer_master",
-                "source_table": "icube.CUSTOMERMASTER",
-                "target_table": "bronze.customer_master",
-                "strategy": "full",
-            },
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [
+            make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+            make_curation_entry("icube", "icube.CUSTOMERMASTER", "customer_master"),
+        ],
+    )
     return config_path, tmp_path
 
 
@@ -76,11 +70,11 @@ class TestRunTable:
 
         con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
         row = con.execute(
-            "SELECT _etl_loaded_at, _etl_run_id FROM bronze.inventory_group LIMIT 1"
+            "SELECT _etl_loaded_at, _etl_run_id FROM bronze.icube_inventory_group LIMIT 1"
         ).fetchone()
         con.close()
         assert row[0] is not None
-        assert "inventory_group" in row[1]
+        assert "icube_inventory_group" in row[1]
 
 
 class TestRunAll:
@@ -106,24 +100,22 @@ class TestRunAll:
 
         results = run_all(cfg, config_path)
         statuses = {r.table_name: r.status for r in results}
-        assert statuses["inventory_group"] == "failure"
-        assert statuses["customer_master"] == "success"
+        assert statuses["icube_inventory_group"] == "failure"
+        assert statuses["icube_customer_master"] == "success"
 
     def test_run_all_does_not_write_validation_json(self, setup_env: tuple[Path, Path]):
-        """L-1: run_all() should NOT write validation JSON — CLI owns that."""
+        """L-1: run_all() should NOT write validation JSON -- CLI owns that."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
         config_path, tmp_path = setup_env
         cfg = load_config(config_path)
 
-        # Remove any pre-existing validation file
         vj_path = config_path.parent / "feather_validation.json"
         vj_path.unlink(missing_ok=True)
 
         run_all(cfg, config_path)
 
-        # run_all should NOT create validation JSON
         assert not vj_path.exists()
 
     def test_first_run_always_extracts(self, setup_env: tuple[Path, Path]):
@@ -148,13 +140,13 @@ class TestRunAll:
         run_table(cfg, cfg.tables[0], tmp_path)
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("inventory_group")
+        wm = sm.read_watermark("icube_inventory_group")
         assert wm is not None
         assert wm["last_file_mtime"] is not None
         assert wm["last_file_hash"] is not None
 
     def test_second_run_skips_unchanged(self, setup_env: tuple[Path, Path]):
-        """Second run on unchanged source → all tables skipped."""
+        """Second run on unchanged source -> all tables skipped."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
@@ -166,7 +158,7 @@ class TestRunAll:
         assert all(r.status == "skipped" for r in results2)
 
     def test_modified_source_reextracts(self, setup_env: tuple[Path, Path]):
-        """Modify source file → next run extracts again."""
+        """Modify source file -> next run extracts again."""
         import time
 
         from feather_etl.config import load_config
@@ -177,8 +169,7 @@ class TestRunAll:
 
         run_all(cfg, config_path)
 
-        # Modify source: add a row to change content and hash
-        time.sleep(0.05)  # ensure mtime differs on coarse-resolution filesystems
+        time.sleep(0.05)
         source_db = tmp_path / "client.duckdb"
         con = duckdb.connect(str(source_db))
         con.execute(
@@ -191,7 +182,7 @@ class TestRunAll:
         assert all(r.status == "success" for r in results2)
 
     def test_touch_source_skips(self, setup_env: tuple[Path, Path]):
-        """Touch source file (mtime changes, content identical) → skipped."""
+        """Touch source file (mtime changes, content identical) -> skipped."""
         import os
         import time
 
@@ -203,7 +194,6 @@ class TestRunAll:
 
         run_all(cfg, config_path)
 
-        # Touch: update mtime without changing content
         time.sleep(0.05)
         os.utime(tmp_path / "client.duckdb", None)
 
@@ -224,7 +214,6 @@ class TestRunAll:
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
         status = sm.get_status()
-        # get_status returns last run per table — should be "skipped"
         assert all(s["status"] == "skipped" for s in status)
 
     def test_failed_extraction_doesnt_update_watermark(
@@ -237,15 +226,13 @@ class TestRunAll:
 
         config_path, tmp_path = setup_env
         cfg = load_config(config_path)
-        # Point to nonexistent table to trigger failure
         cfg.tables[0].source_table = "icube.NONEXISTENT"
 
         run_table(cfg, cfg.tables[0], tmp_path)
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("inventory_group")
-        # Watermark value not advanced on failure (retry metadata may exist)
+        wm = sm.read_watermark("icube_inventory_group")
         if wm is not None:
             assert wm["last_value"] is None
             assert wm["last_run_at"] is None
-            assert wm["retry_count"] == 1  # retry state set by V14
+            assert wm["retry_count"] == 1

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestIncrementRetry:
@@ -35,7 +36,6 @@ class TestIncrementRetry:
         sm.increment_retry("orders")
         wm = sm.read_watermark("orders")
 
-        # retry_after should be ~15 min from now
         retry_after = wm["retry_after"]
         assert retry_after is not None
         expected_min = before + timedelta(minutes=14)
@@ -43,7 +43,6 @@ class TestIncrementRetry:
         assert expected_min <= retry_after <= expected_max
 
     def test_two_failures_30_min_backoff(self, tmp_path: Path):
-        """AC-FR13.a: 2 failures → retry_after = now + 30 min."""
         from feather_etl.state import StateManager
 
         sm = StateManager(tmp_path / "state.duckdb")
@@ -62,7 +61,6 @@ class TestIncrementRetry:
         assert expected_min <= retry_after <= expected_max
 
     def test_ten_failures_capped_at_120_min(self, tmp_path: Path):
-        """AC-FR13.c: 10 failures → capped at 120 min, not 150."""
         from feather_etl.state import StateManager
 
         sm = StateManager(tmp_path / "state.duckdb")
@@ -73,7 +71,7 @@ class TestIncrementRetry:
             sm.increment_retry("orders")
 
         before = datetime.now(timezone.utc).replace(tzinfo=None)
-        sm.increment_retry("orders")  # 10th failure
+        sm.increment_retry("orders")
         wm = sm.read_watermark("orders")
 
         assert wm["retry_count"] == 10
@@ -87,7 +85,6 @@ class TestIncrementRetry:
 
         sm = StateManager(tmp_path / "state.duckdb")
         sm.init_state()
-        # No write_watermark call — table doesn't exist yet
 
         sm.increment_retry("new_table")
         wm = sm.read_watermark("new_table")
@@ -118,7 +115,6 @@ class TestResetRetry:
         sm.init_state()
         sm.write_watermark("orders", strategy="full")
 
-        # Should not error
         sm.reset_retry("orders")
         wm = sm.read_watermark("orders")
         assert wm["retry_count"] == 0
@@ -143,7 +139,6 @@ class TestShouldSkipRetry:
         sm.init_state()
         sm.write_watermark("orders", strategy="full")
 
-        # Record a failure run so error message is available
         now = datetime.now(timezone.utc)
         sm.record_run(
             run_id="orders_fail",
@@ -169,7 +164,6 @@ class TestShouldSkipRetry:
         sm.write_watermark("orders", strategy="full")
         sm.increment_retry("orders")
 
-        # Manually set retry_after to past (naive UTC, matching DuckDB storage)
         con = duckdb.connect(str(sm.path))
         past = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=5)
         con.execute(
@@ -274,19 +268,15 @@ def _make_broken_config(tmp_path: Path) -> Path:
     client_db = tmp_path / "client.duckdb"
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "orders",
-                "source_table": "icube.nonexistent_table_xyz",
-                "target_table": "bronze.orders",
-                "strategy": "full",
-            }
-        ],
     }
     config_file = tmp_path / "feather.yaml"
     config_file.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("icube", "icube.nonexistent_table_xyz", "orders")],
+    )
     return config_file
 
 
@@ -295,19 +285,15 @@ def _make_good_config(tmp_path: Path) -> Path:
     client_db = tmp_path / "client.duckdb"
     shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
     config = {
-        "sources": [{"type": "duckdb", "path": str(client_db)}],
+        "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
         "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-        "tables": [
-            {
-                "name": "inventory_group",
-                "source_table": "icube.InventoryGroup",
-                "target_table": "bronze.inventory_group",
-                "strategy": "full",
-            }
-        ],
     }
     config_file = tmp_path / "feather.yaml"
     config_file.write_text(yaml.dump(config, default_flow_style=False))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("icube", "icube.InventoryGroup", "inventory_group")],
+    )
     return config_file
 
 
@@ -324,7 +310,7 @@ class TestRetryPipelineIntegration:
         assert result.status == "failure"
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        wm = sm.read_watermark("orders")
+        wm = sm.read_watermark("icube_orders")
         assert wm is not None
         assert wm["retry_count"] == 1
         assert wm["retry_after"] is not None
@@ -336,10 +322,8 @@ class TestRetryPipelineIntegration:
         config_path = _make_broken_config(tmp_path)
         cfg = load_config(config_path)
 
-        # First failure sets backoff
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Second call should skip (in backoff window)
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "skipped"
         assert result.error_message is not None
@@ -349,37 +333,34 @@ class TestRetryPipelineIntegration:
         from feather_etl.pipeline import run_table
         from feather_etl.state import StateManager
 
-        # Start with good config, manually set retry state
         config_path = _make_good_config(tmp_path)
         cfg = load_config(config_path)
 
         sm = StateManager(tmp_path / "feather_state.duckdb")
         sm.init_state()
-        sm.write_watermark("inventory_group", strategy="full")
-        sm.increment_retry("inventory_group")
-        sm.increment_retry("inventory_group")
+        sm.write_watermark("icube_inventory_group", strategy="full")
+        sm.increment_retry("icube_inventory_group")
+        sm.increment_retry("icube_inventory_group")
 
-        wm = sm.read_watermark("inventory_group")
+        wm = sm.read_watermark("icube_inventory_group")
         assert wm["retry_count"] == 2
 
-        # Manually clear backoff so the run actually executes
-        sm.reset_retry("inventory_group")
-        sm.increment_retry("inventory_group")  # set count=1 but far future backoff
+        sm.reset_retry("icube_inventory_group")
+        sm.increment_retry("icube_inventory_group")
         import duckdb
 
         con = duckdb.connect(str(sm.path))
         con.execute(
             "UPDATE _watermarks SET retry_count = 2, retry_after = ? "
-            "WHERE table_name = 'inventory_group'",
+            "WHERE table_name = 'icube_inventory_group'",
             [datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=5)],
         )
         con.close()
 
-        # Run should succeed and reset retry
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
 
-        wm = sm.read_watermark("inventory_group")
+        wm = sm.read_watermark("icube_inventory_group")
         assert wm["retry_count"] == 0
         assert wm["retry_after"] is None
 
@@ -391,29 +372,22 @@ class TestRetryPipelineIntegration:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "client.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "icube", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "inventory_group",
-                    "source_table": "icube.InventoryGroup",
-                    "target_table": "bronze.inventory_group",
-                    "strategy": "full",
-                },
-                {
-                    "name": "bad_table",
-                    "source_table": "icube.nonexistent_table",
-                    "target_table": "bronze.bad_table",
-                    "strategy": "full",
-                },
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config, default_flow_style=False))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry("icube", "icube.InventoryGroup", "inventory_group"),
+                make_curation_entry("icube", "icube.nonexistent_table", "bad_table"),
+            ],
+        )
 
         cfg = load_config(config_file)
         results = run_all(cfg, config_file)
 
         statuses = {r.table_name: r.status for r in results}
-        assert statuses["inventory_group"] == "success"
-        assert statuses["bad_table"] == "failure"
+        assert statuses["icube_inventory_group"] == "success"
+        assert statuses["icube_bad_table"] == "failure"

--- a/tests/test_schema_drift.py
+++ b/tests/test_schema_drift.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import duckdb
 
 from feather_etl.schema_drift import detect_drift
+from tests.helpers import make_curation_entry, write_curation
 
 
 class TestDetectDrift:
@@ -91,7 +92,6 @@ class TestStateSnapshot:
         sm.save_schema_snapshot("orders", [("id", "INTEGER"), ("email", "VARCHAR")])
 
         stored = sm.get_schema_snapshot("orders")
-        # Should have new schema, not old
         cols = [c[0] for c in stored]
         assert "email" in cols
         assert "name" not in cols
@@ -99,7 +99,6 @@ class TestStateSnapshot:
 
 class TestPipelineIntegration:
     def test_first_run_saves_baseline(self, tmp_path: Path):
-        """First extraction saves schema baseline, no drift reported."""
         import shutil
         import yaml
 
@@ -111,31 +110,32 @@ class TestPipelineIntegration:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customers",
-                    "source_table": "erp.customers",
-                    "target_table": "bronze.customers",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.customers",
+                    "customers",
+                    primary_key=["customer_id"],
+                ),
+            ],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
 
-        # Check baseline saved
         sm = StateManager(tmp_path / "feather_state.duckdb")
-        snapshot = sm.get_schema_snapshot("customers")
+        snapshot = sm.get_schema_snapshot("src_customers")
         assert snapshot is not None
         assert len(snapshot) > 0
 
     def test_schema_changes_logged_in_runs(self, tmp_path: Path):
-        """Schema drift is detected and logged in _runs.schema_changes."""
         import json
         import shutil
         import yaml
@@ -148,44 +148,42 @@ class TestPipelineIntegration:
         client_db = tmp_path / "client.duckdb"
         shutil.copy2(FIXTURES_DIR / "sample_erp.duckdb", client_db)
         config = {
-            "sources": [{"type": "duckdb", "path": str(client_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(client_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "customers",
-                    "source_table": "erp.customers",
-                    "target_table": "bronze.customers",
-                    "strategy": "full",
-                }
-            ],
         }
         (tmp_path / "feather.yaml").write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [
+                make_curation_entry(
+                    "src",
+                    "erp.customers",
+                    "customers",
+                    primary_key=["customer_id"],
+                ),
+            ],
+        )
         cfg = load_config(tmp_path / "feather.yaml")
 
-        # First run: saves baseline
         run_table(cfg, cfg.tables[0], tmp_path)
 
-        # Modify source schema: add a column
         con = duckdb.connect(str(client_db))
         con.execute("ALTER TABLE erp.customers ADD COLUMN phone VARCHAR")
         con.close()
 
-        # Ensure mtime changes so change detection triggers re-extraction
         import time
         import os
 
         time.sleep(0.1)
         os.utime(str(client_db), None)
 
-        # Second run: should detect drift
         result = run_table(cfg, cfg.tables[0], tmp_path)
         assert result.status == "success"
 
-        # Check _runs.schema_changes is populated
         sm = StateManager(tmp_path / "feather_state.duckdb")
         con = sm._connect()
         rows = con.execute(
-            "SELECT schema_changes FROM _runs WHERE table_name = 'customers' "
+            "SELECT schema_changes FROM _runs WHERE table_name = 'src_customers' "
             "AND schema_changes IS NOT NULL"
         ).fetchall()
         con.close()

--- a/tests/test_sqlserver.py
+++ b/tests/test_sqlserver.py
@@ -403,10 +403,13 @@ def test_sqlserver_connection_string_builder_trusts_self_signed_cert(tmp_path) -
     """
     from feather_etl.config import load_config
 
+    from tests.helpers import make_curation_entry, write_curation
+
     cfg = {
         "sources": [
             {
                 "type": "sqlserver",
+                "name": "erp",
                 "host": "10.0.0.1",
                 "port": 1433,
                 "database": "mydb",
@@ -415,18 +418,14 @@ def test_sqlserver_connection_string_builder_trusts_self_signed_cert(tmp_path) -
             }
         ],
         "destination": {"path": str(tmp_path / "dest.duckdb")},
-        "tables": [
-            {
-                "name": "orders",
-                "source_table": "dbo.orders",
-                "strategy": "full",
-                "target_table": "bronze.orders",
-            }
-        ],
     }
     config_file = write_config(tmp_path, cfg)
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "dbo.orders", "orders")],
+    )
 
-    result = load_config(config_file)
+    result = load_config(config_file, validate=False)
     assert result.sources[0].connection_string is not None
     assert "TrustServerCertificate=yes" in result.sources[0].connection_string
     assert "ODBC Driver 18 for SQL Server" in result.sources[0].connection_string

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -17,6 +17,8 @@ from feather_etl.transforms import (
     rebuild_materialized_gold,
 )
 
+from tests.helpers import make_curation_entry, write_curation
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -355,7 +357,6 @@ class TestExecuteTransforms:
         assert results[0].status == "success"
         assert results[0].type == "table"
 
-        # Verify it's a TABLE not a VIEW
         info = con.execute(
             "SELECT table_type FROM information_schema.tables "
             "WHERE table_schema='gold' AND table_name='emp_snapshot'"
@@ -413,7 +414,6 @@ class TestExecuteTransforms:
             sql="SELECT '${unknown}' AS val, * FROM bronze.employees",
         )
 
-        # safe_substitute doesn't raise on unknown vars — leaves them as-is
         results = execute_transforms(con, [t], variables={})
         assert results[0].status == "success"
         con.close()
@@ -461,15 +461,12 @@ class TestRebuildMaterializedGold:
             materialized=True,
         )
 
-        # Initial creation
         execute_transforms(con, [mat])
         count1 = con.execute("SELECT count(*) FROM gold.emp_snap").fetchone()[0]
         assert count1 == 3
 
-        # Insert new data into bronze
         con.execute("INSERT INTO bronze.employees VALUES (4, 'E004', 'Diana')")
 
-        # Rebuild
         rebuild_materialized_gold(con, [mat])
         count2 = con.execute("SELECT count(*) FROM gold.emp_snap").fetchone()[0]
         assert count2 == 4
@@ -492,12 +489,10 @@ class TestE2ETransformPipeline:
     """End-to-end: bronze data -> discover -> order -> execute -> verify."""
 
     def test_full_pipeline_with_fixtures(self, tmp_path: Path):
-        # 1. Set up bronze data
         db_path = tmp_path / "test.duckdb"
         con = duckdb.connect(str(db_path))
         _make_bronze_tables(con)
 
-        # 2. Write transform SQL files
         _write_sql(
             tmp_path,
             "silver",
@@ -545,46 +540,38 @@ class TestE2ETransformPipeline:
             ),
         )
 
-        # 3. Discover and order
         transforms = discover_transforms(tmp_path)
         assert len(transforms) == 3
 
         ordered = build_execution_order(transforms)
         names = [t.qualified_name for t in ordered]
 
-        # Gold must come after both silver deps
         assert names.index("silver.employee_master") < names.index("gold.sales_summary")
         assert names.index("silver.item_master") < names.index("gold.sales_summary")
 
-        # 4. Execute all transforms
         results = execute_transforms(con, ordered)
         assert all(r.status == "success" for r in results)
 
-        # 5. Verify silver views
         emp_rows = con.execute("SELECT * FROM silver.employee_master").fetchall()
         assert len(emp_rows) == 3
-        assert emp_rows[0][2] == "Alice"  # employee_name
+        assert emp_rows[0][2] == "Alice"
 
         item_rows = con.execute("SELECT * FROM silver.item_master").fetchall()
         assert len(item_rows) == 2
 
-        # 6. Verify gold materialized table
         gold_rows = con.execute(
             "SELECT * FROM gold.sales_summary ORDER BY sale_id"
         ).fetchall()
         assert len(gold_rows) == 3
-        # sale_id=1: Alice, Widget, Hardware, 100.00
         assert gold_rows[0][1] == "Alice"
         assert gold_rows[0][2] == "Widget"
 
-        # 7. Verify it's a TABLE (materialized)
         ttype = con.execute(
             "SELECT table_type FROM information_schema.tables "
             "WHERE table_schema='gold' AND table_name='sales_summary'"
         ).fetchone()
         assert ttype[0] == "BASE TABLE"
 
-        # 8. Insert new data into bronze, rebuild gold
         con.execute("INSERT INTO bronze.sales VALUES (4, 'E003', 'I001', 500.00)")
         rebuild_results = rebuild_materialized_gold(con, ordered)
         assert len(rebuild_results) == 1
@@ -596,8 +583,6 @@ class TestE2ETransformPipeline:
         con.close()
 
     def test_bronze_dependencies_silently_skipped(self, tmp_path: Path):
-        """Dependencies on bronze.* are external (extraction layer) and should
-        be silently ignored by the dependency graph — no error raised."""
         db_path = tmp_path / "test.duckdb"
         con = duckdb.connect(str(db_path))
         _make_bronze_tables(con)
@@ -615,13 +600,11 @@ class TestE2ETransformPipeline:
         assert len(ordered) == 1
         assert ordered[0].qualified_name == "silver.emp"
 
-        # Verify it actually executes
         results = execute_transforms(con, ordered)
         assert results[0].status == "success"
         con.close()
 
     def test_missing_silver_dependency_still_raises(self, tmp_path: Path):
-        """Dependencies on silver/gold that don't exist should still error."""
         _write_sql(
             tmp_path, "gold", "bad", ("-- depends_on: silver.nonexistent\nSELECT 1")
         )
@@ -632,7 +615,7 @@ class TestE2ETransformPipeline:
 
 
 # ===========================================================================
-# Task 4: CLI integration — feather setup
+# Task 4: CLI integration -- feather setup
 # ===========================================================================
 
 
@@ -640,13 +623,11 @@ class TestCLISetupTransforms:
     """Test that `feather setup` discovers and executes transforms."""
 
     def test_setup_creates_transforms(self, tmp_path: Path):
-        """feather setup with transform SQL files creates views/tables in DuckDB."""
         import yaml
         from typer.testing import CliRunner
 
         from feather_etl.cli import app
 
-        # Create a source DB (needed for config validation)
         source_db = tmp_path / "source.duckdb"
         con = duckdb.connect(str(source_db))
         con.execute("CREATE SCHEMA IF NOT EXISTS erp")
@@ -654,36 +635,29 @@ class TestCLISetupTransforms:
         con.execute("INSERT INTO erp.employees VALUES (1, 'Alice'), (2, 'Bob')")
         con.close()
 
-        # Pre-populate destination with bronze data (normally done by `feather run`)
         dest_db = tmp_path / "feather_data.duckdb"
         con = duckdb.connect(str(dest_db))
         con.execute("CREATE SCHEMA IF NOT EXISTS bronze")
-        con.execute("CREATE TABLE bronze.employees (id INT, name VARCHAR)")
-        con.execute("INSERT INTO bronze.employees VALUES (1, 'Alice'), (2, 'Bob')")
+        con.execute("CREATE TABLE bronze.src_employees (id INT, name VARCHAR)")
+        con.execute("INSERT INTO bronze.src_employees VALUES (1, 'Alice'), (2, 'Bob')")
         con.close()
 
-        # Write feather.yaml
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(dest_db)},
-            "tables": [
-                {
-                    "name": "employees",
-                    "source_table": "erp.employees",
-                    "target_table": "bronze.employees",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.employees", "employees")],
+        )
 
-        # Write transform SQL files
         _write_sql(
             tmp_path,
             "silver",
             "emp_clean",
-            ("SELECT id, name AS employee_name FROM bronze.employees"),
+            ("SELECT id, name AS employee_name FROM bronze.src_employees"),
         )
 
         runner = CliRunner()
@@ -694,7 +668,6 @@ class TestCLISetupTransforms:
         assert "1 silver view(s)" in result.output
 
     def test_setup_no_transforms_dir_ok(self, tmp_path: Path):
-        """feather setup without transforms/ dir should not fail."""
         import yaml
         from typer.testing import CliRunner
 
@@ -707,19 +680,15 @@ class TestCLISetupTransforms:
         con.close()
 
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(tmp_path / "feather_data.duckdb")},
-            "tables": [
-                {
-                    "name": "employees",
-                    "source_table": "erp.employees",
-                    "target_table": "bronze.employees",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.employees", "employees")],
+        )
 
         runner = CliRunner()
         result = runner.invoke(app, ["setup", "--config", str(config_file)])
@@ -729,7 +698,7 @@ class TestCLISetupTransforms:
 
 
 # ===========================================================================
-# Task 5: Pipeline integration — feather run
+# Task 5: Pipeline integration -- feather run
 # ===========================================================================
 
 
@@ -737,13 +706,11 @@ class TestPipelineTransformRebuild:
     """Test that run_all() rebuilds materialized gold after extraction."""
 
     def test_run_rebuilds_materialized_gold(self, tmp_path: Path):
-        """After extraction, materialized gold tables are rebuilt."""
         import yaml
 
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
-        # Create source with data
         source_db = tmp_path / "source.duckdb"
         con = duckdb.connect(str(source_db))
         con.execute("CREATE SCHEMA IF NOT EXISTS erp")
@@ -753,26 +720,21 @@ class TestPipelineTransformRebuild:
 
         dest_db = tmp_path / "feather_data.duckdb"
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(dest_db)},
-            "tables": [
-                {
-                    "name": "employees",
-                    "source_table": "erp.employees",
-                    "target_table": "bronze.employees",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.employees", "employees")],
+        )
 
-        # Write transforms
         _write_sql(
             tmp_path,
             "silver",
             "emp_clean",
-            "SELECT id, name AS employee_name FROM bronze.employees",
+            "SELECT id, name AS employee_name FROM bronze.src_employees",
         )
         _write_sql(
             tmp_path,
@@ -790,20 +752,17 @@ class TestPipelineTransformRebuild:
 
         assert any(r.status == "success" for r in results)
 
-        # Verify gold table was created by the rebuild
         con = duckdb.connect(str(dest_db))
         gold_rows = con.execute("SELECT * FROM gold.emp_snapshot").fetchall()
         assert len(gold_rows) == 2
         con.close()
 
     def test_run_mode_switch_rematerializes_gold(self, tmp_path: Path):
-        """Dev→prod mode switch rematerializes gold VIEW as TABLE even when extraction skipped."""
         import yaml
 
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 
-        # Create source with data
         source_db = tmp_path / "source.duckdb"
         con = duckdb.connect(str(source_db))
         con.execute("CREATE SCHEMA IF NOT EXISTS erp")
@@ -813,27 +772,22 @@ class TestPipelineTransformRebuild:
 
         dest_db = tmp_path / "feather_data.duckdb"
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(dest_db)},
             "mode": "dev",
-            "tables": [
-                {
-                    "name": "employees",
-                    "source_table": "erp.employees",
-                    "target_table": "bronze.employees",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.employees", "employees")],
+        )
 
-        # Write transforms
         _write_sql(
             tmp_path,
             "silver",
             "emp_clean",
-            "SELECT id, name AS employee_name FROM bronze.employees",
+            "SELECT id, name AS employee_name FROM bronze.src_employees",
         )
         _write_sql(
             tmp_path,
@@ -846,7 +800,6 @@ class TestPipelineTransformRebuild:
             ),
         )
 
-        # Run 1: dev mode — gold should be a VIEW
         cfg_dev = load_config(config_file)
         results1 = run_all(cfg_dev, config_file)
         assert any(r.status == "success" for r in results1)
@@ -859,7 +812,6 @@ class TestPipelineTransformRebuild:
         con.close()
         assert gold_type_dev == "VIEW"
 
-        # Run 2: switch to prod mode — extraction skipped (unchanged), but gold should become TABLE
         config["mode"] = "prod"
         config_file.write_text(yaml.dump(config))
         cfg_prod = load_config(config_file)
@@ -872,13 +824,9 @@ class TestPipelineTransformRebuild:
             "WHERE table_schema='gold' AND table_name='emp_snapshot'"
         ).fetchone()[0]
         con.close()
-        assert gold_type_prod == "BASE TABLE", (
-            f"Expected gold to be materialized as BASE TABLE after prod mode switch, "
-            f"got {gold_type_prod}"
-        )
+        assert gold_type_prod == "BASE TABLE"
 
     def test_run_no_rebuild_when_all_skipped(self, tmp_path: Path):
-        """If all tables are skipped, gold table still exists from prior run."""
         import yaml
 
         from feather_etl.config import load_config
@@ -893,19 +841,15 @@ class TestPipelineTransformRebuild:
 
         dest_db = tmp_path / "feather_data.duckdb"
         config = {
-            "sources": [{"type": "duckdb", "path": str(source_db)}],
+            "sources": [{"type": "duckdb", "name": "src", "path": str(source_db)}],
             "destination": {"path": str(dest_db)},
-            "tables": [
-                {
-                    "name": "employees",
-                    "source_table": "erp.employees",
-                    "target_table": "bronze.employees",
-                    "strategy": "full",
-                }
-            ],
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(config))
+        write_curation(
+            tmp_path,
+            [make_curation_entry("src", "erp.employees", "employees")],
+        )
 
         _write_sql(
             tmp_path, "gold", "emp_snap", ("-- materialized: true\nSELECT 1 AS val")
@@ -913,15 +857,12 @@ class TestPipelineTransformRebuild:
 
         cfg = load_config(config_file)
 
-        # First run: extracts data (success)
         results1 = run_all(cfg, config_file)
         assert any(r.status == "success" for r in results1)
 
-        # Second run: should skip (source unchanged)
         results2 = run_all(cfg, config_file)
         assert all(r.status == "skipped" for r in results2)
 
-        # Gold table should still exist from the first run's rebuild
         con = duckdb.connect(str(dest_db))
         row = con.execute("SELECT * FROM gold.emp_snap").fetchone()
         assert row is not None


### PR DESCRIPTION
## Summary

- **MySQL source** (#25): Full MySQLSource implementation with discover, extract, detect_changes, get_schema, list_databases, and type mapping
- **Multi-source pipeline** (#8, #15): `feather run` now extracts tables from multiple sources using `discovery/curation.json` as the table manifest — replaces the YAML `tables:` section
- **DatabaseSource refactor** (#27): `_expand_db_sources` extracted to shared utility using base class isinstance check

### Key changes

- `discovery/curation.json` is now the sole table manifest — each entry with `decision: "include"` is extracted, with `source_db` resolved to the correct source at config load time
- Bronze target names derived from `<source_db>_<alias>` with normalization and collision detection
- `_enforce_single_source` gate removed from all commands (run, setup, status, validate, history)
- `run_table()` accepts source as parameter; `run_all()` resolves the right source per table
- `validate_source_table()` retained in config layer — runs per-table against resolved source
- Pipeline validation rules posted as comments on #29 (curation validator)

### Files

- **New:** `src/feather_etl/curation.py`, `src/feather_etl/sources/expand.py`, `src/feather_etl/sources/mysql.py`
- **New tests:** `tests/test_curation.py`, `tests/test_curation_config_integration.py`, `tests/test_multi_source_e2e.py`, `tests/test_expand_db_sources.py`, `tests/test_mysql.py`
- **Modified:** 30+ test files migrated from YAML `tables:` to curation.json fixtures

### Test results

629 passed, 16 skipped (skips = postgres/mysql requiring external DBs)

## Test plan

- [x] Unit tests for curation loader (15 tests) — filters, naming, collisions, resolution
- [x] Unit tests for expand_db_sources (3 tests) — file pass-through, single db, multi-db expansion
- [x] Integration tests for load_config + curation (3 tests)
- [x] E2e multi-source extraction (3 tests) — 2 DuckDB sources, row counts, --table filter
- [x] All existing tests migrated and passing (629 total)
- [ ] Manual: test against rama_dw with real SQL Server + MySQL sources (requires VPN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)