### PR TITLE
refactor: thin-CLI ↔ pure-core split for discover, setup, validate, status, history (#43)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
+++ b/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
@@ -90,10 +90,22 @@ def _make_state_with_runs(state_path: Path) -> None:
     sm = StateManager(state_path)
     sm.init_state()
     now = datetime.now(timezone.utc).replace(tzinfo=None)
-    sm.record_run_start("run-1", "orders", now)
-    sm.record_run_complete("run-1", "success", rows_loaded=10)
-    sm.record_run_start("run-2", "customers", now)
-    sm.record_run_complete("run-2", "success", rows_loaded=5)
+    sm.record_run(
+        run_id="run-1",
+        table_name="orders",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=10,
+    )
+    sm.record_run(
+        run_id="run-2",
+        table_name="customers",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=5,
+    )
 
 
 class TestLoadHistory:
@@ -333,10 +345,22 @@ def _make_state_with_runs(state_path: Path) -> None:
     sm = StateManager(state_path)
     sm.init_state()
     now = datetime.now(timezone.utc).replace(tzinfo=None)
-    sm.record_run_start("run-1", "orders", now)
-    sm.record_run_complete("run-1", "success", rows_loaded=10)
-    sm.record_run_start("run-2", "customers", now)
-    sm.record_run_complete("run-2", "success", rows_loaded=5)
+    sm.record_run(
+        run_id="run-1",
+        table_name="orders",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=10,
+    )
+    sm.record_run(
+        run_id="run-2",
+        table_name="customers",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=5,
+    )
 
 
 class TestLoadStatus:

--- a/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
+++ b/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
@@ -1,0 +1,2210 @@
+# Thin-CLI Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `commands/discover.py`, `setup.py`, `validate.py`, `status.py`, `history.py` into thin Typer wrappers, with their orchestration extracted into pure top-level modules in `src/feather_etl/`. Behavior-preserving — every CLI invocation produces byte-identical output and exit codes.
+
+**Architecture:** For each command, split into two layers. The top-level `<name>.py` module owns orchestration, returns dataclass results (or raises domain exceptions for fatal preconditions), and never imports `typer`. The `commands/<name>.py` module is a thin Typer wrapper that handles flag parsing, prompts, output formatting, and exit-code translation. The pattern is already proven by `commands/run.py` ↔ `pipeline.py` and `commands/cache.py` ↔ `cache.py`.
+
+**Tech Stack:** Python 3.10+, Typer (CLI), DuckDB (state + destination), pytest + `typer.testing.CliRunner` (CLI tests), pytest with real fixtures (core unit tests, no `CliRunner`), `uv` for dep management.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-thin-cli-refactor-design.md`
+**Issue:** [#43](https://github.com/siraj-samsudeen/feather-etl/issues/43)
+
+---
+
+## Preconditions
+
+- [ ] **Run both test suites and confirm green before any edits.**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (currently ~653 per `CLAUDE.md`).
+
+Run: `bash scripts/hands_on_test.sh`
+Expected: all 61 checks pass.
+
+If anything is red before you start, stop and surface it — do not proceed.
+
+---
+
+## File structure
+
+**New files:**
+
+| Path | Responsibility |
+|---|---|
+| `src/feather_etl/exceptions.py` | Shared domain exceptions (`StateDBMissingError`). |
+| `src/feather_etl/history.py` | `load_history()` — wraps `StateManager.get_history()` with the "no DB" precondition. |
+| `src/feather_etl/status.py` | `load_status()` — wraps `StateManager.get_status()` with the "no DB" precondition. |
+| `src/feather_etl/validate.py` | `run_validate()` + `ValidateReport` + `SourceCheckResult`. Iterates sources, calls `source.check()`, returns a report. |
+| `src/feather_etl/setup.py` | `run_setup()` + `SetupResult`. Initializes state DB, creates schemas, runs transforms. |
+| `src/feather_etl/discover.py` | `detect_renames_for_sources()`, `apply_rename_decision()`, `run_discover()` + `DiscoverReport`, `SourceDiscoveryResult`, `RenameDetection`. Pure orchestration with rename phase split out. |
+| `tests/test_core_module_purity.py` | Parametrized assertion that no pure-core module imports `typer`. |
+| `tests/test_history_core.py` | Direct unit tests for `load_history()`. No `CliRunner`. |
+| `tests/test_status_core.py` | Direct unit tests for `load_status()`. No `CliRunner`. |
+| `tests/test_validate_core.py` | Direct unit tests for `run_validate()`. No `CliRunner`. |
+| `tests/test_setup_core.py` | Direct unit tests for `run_setup()`. No `CliRunner`. |
+| `tests/test_discover_core.py` | Direct unit tests for the three discover top-level functions. No `CliRunner`. |
+
+**Modified files:**
+
+| Path | Change |
+|---|---|
+| `src/feather_etl/commands/history.py` | Shrink from 75 → ~40 lines; delegate to `feather_etl.history.load_history`. |
+| `src/feather_etl/commands/status.py` | Shrink from 68 → ~40 lines; delegate to `feather_etl.status.load_status`. |
+| `src/feather_etl/commands/validate.py` | Shrink from 66 → ~40 lines; delegate to `feather_etl.validate.run_validate`. |
+| `src/feather_etl/commands/setup.py` | Shrink from 105 → ~50 lines; delegate to `feather_etl.setup.run_setup`. |
+| `src/feather_etl/commands/discover.py` | Shrink from 274 → ~80 lines; delegate to `feather_etl.discover.{detect_renames_for_sources, apply_rename_decision, run_discover}`. |
+
+**Untouched (must not edit):** `cli.py`, `commands/_common.py`, `commands/cache.py`, `commands/run.py`, `commands/init.py`, `commands/view.py`, `pipeline.py`, `cache.py`, `state.py`, `config.py`, `init_wizard.py`, `viewer_server.py`, `output.py`, all `sources/*`, `destinations/*`, `transforms.py`. (Exception: if Task 3's purity test surfaces an unexpected `typer` import in `viewer_server.py` or `init_wizard.py`, remove it in the same commit.)
+
+---
+
+## Task 1: Extract `history` core
+
+**Files:**
+- Create: `src/feather_etl/exceptions.py`
+- Create: `src/feather_etl/history.py`
+- Create: `tests/test_history_core.py`
+- Modify: `src/feather_etl/commands/history.py` (shrink to thin wrapper)
+
+- [ ] **Step 1.1: Write failing test for `load_history` happy path**
+
+Create `tests/test_history_core.py` with the following content:
+
+```python
+"""Direct unit tests for feather_etl.history.load_history()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _make_state_with_runs(state_path: Path) -> None:
+    """Create a state DB and insert two run rows."""
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    sm.init_state()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sm.record_run_start("run-1", "orders", now)
+    sm.record_run_complete("run-1", "success", rows_loaded=10)
+    sm.record_run_start("run-2", "customers", now)
+    sm.record_run_complete("run-2", "success", rows_loaded=5)
+
+
+class TestLoadHistory:
+    def test_returns_rows_from_state_db(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path)
+
+        assert len(rows) == 2
+        assert {r["table_name"] for r in rows} == {"orders", "customers"}
+        assert all(r["status"] == "success" for r in rows)
+
+    def test_filters_by_table_name(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path, table="orders")
+
+        assert len(rows) == 1
+        assert rows[0]["table_name"] == "orders"
+
+    def test_respects_limit(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path, limit=1)
+
+        assert len(rows) == 1
+
+
+class TestLoadHistoryPreconditions:
+    def test_raises_state_db_missing_when_no_db(self, tmp_path: Path):
+        from feather_etl.exceptions import StateDBMissingError
+        from feather_etl.history import load_history
+
+        with pytest.raises(StateDBMissingError):
+            load_history(tmp_path / "missing.duckdb")
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_history_core.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feather_etl.history'` (or `feather_etl.exceptions`).
+
+- [ ] **Step 1.3: Create `exceptions.py`**
+
+Create `src/feather_etl/exceptions.py`:
+
+```python
+"""Shared domain exceptions for feather-etl core modules."""
+
+from __future__ import annotations
+
+
+class StateDBMissingError(Exception):
+    """Raised when an operation requires the state DB but it does not exist on disk."""
+```
+
+- [ ] **Step 1.4: Create `history.py`**
+
+Create `src/feather_etl/history.py`:
+
+```python
+"""`feather history` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.exceptions import StateDBMissingError
+
+
+def load_history(
+    state_path: Path,
+    *,
+    table: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Return recent run history rows from the state DB.
+
+    Raises ``StateDBMissingError`` if the state DB does not exist.
+    """
+    if not state_path.exists():
+        raise StateDBMissingError(str(state_path))
+
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    return sm.get_history(table_name=table, limit=limit)
+```
+
+- [ ] **Step 1.5: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_history_core.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 1.6: Rewrite `commands/history.py` as thin wrapper**
+
+Replace `src/feather_etl/commands/history.py` with:
+
+```python
+"""`feather history` command — thin Typer wrapper over feather_etl.history."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from feather_etl.commands._common import (
+    _is_json,
+    _load_and_validate,
+)
+from feather_etl.exceptions import StateDBMissingError
+from feather_etl.history import load_history
+from feather_etl.output import emit
+
+
+def history(
+    ctx: typer.Context,
+    config: Path = typer.Option("feather.yaml", "--config"),
+    table: str | None = typer.Option(None, "--table", help="Filter by table name."),
+    limit: int = typer.Option(20, "--limit", help="Maximum number of runs to show."),
+) -> None:
+    """Show recent run history."""
+    cfg = _load_and_validate(config)
+    state_path = cfg.config_dir / "feather_state.duckdb"
+
+    try:
+        rows = load_history(state_path, table=table, limit=limit)
+    except StateDBMissingError:
+        typer.echo("No state DB found. Run 'feather run' first.", err=True)
+        raise typer.Exit(code=1)
+
+    if not rows:
+        if not _is_json(ctx):
+            typer.echo("No runs recorded yet.")
+        return
+
+    if _is_json(ctx):
+        emit(
+            [
+                {
+                    "run_id": row["run_id"],
+                    "table_name": row["table_name"],
+                    "started_at": str(row.get("started_at", "")),
+                    "ended_at": str(row.get("ended_at", "")),
+                    "status": row["status"],
+                    "rows_loaded": row.get("rows_loaded"),
+                    "error_message": row.get("error_message"),
+                }
+                for row in rows
+            ],
+            json_mode=True,
+        )
+    else:
+        typer.echo(
+            f"{'Table':<30} {'Status':<12} {'Rows':<10} {'Started':<28} {'Run ID'}"
+        )
+        typer.echo("-" * 100)
+        for row in rows:
+            typer.echo(
+                f"{row['table_name']:<30} {row['status']:<12} "
+                f"{row.get('rows_loaded', '-') or '-'!s:<10} "
+                f"{str(row.get('started_at', '-')):<28} {row.get('run_id', '-')}"
+            )
+            if row.get("error_message"):
+                error = str(row["error_message"])
+                if len(error) > 80:
+                    error = error[:77] + "..."
+                typer.echo(f"  Error: {error}")
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="history")(history)
+```
+
+- [ ] **Step 1.7: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (now ~657 — gained 4 from `test_history_core.py`).
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add src/feather_etl/exceptions.py src/feather_etl/history.py \
+        src/feather_etl/commands/history.py tests/test_history_core.py
+git commit -m "refactor(history): extract pure core into feather_etl.history (#43)
+
+Split commands/history.py into a thin Typer wrapper that delegates
+to feather_etl.history.load_history(). Introduce
+feather_etl.exceptions.StateDBMissingError as the precondition
+exception, reused by status in the next task.
+
+The wrapper preserves exact CLI behavior: same prompts, same error
+messages, same exit codes, same JSON output. Verified by the existing
+tests/commands/test_history.py suite plus four new direct unit tests
+in tests/test_history_core.py that exercise the core without
+CliRunner."
+```
+
+---
+
+## Task 2: Extract `status` core
+
+**Files:**
+- Create: `src/feather_etl/status.py`
+- Create: `tests/test_status_core.py`
+- Modify: `src/feather_etl/commands/status.py` (shrink to thin wrapper)
+
+- [ ] **Step 2.1: Write failing test for `load_status`**
+
+Create `tests/test_status_core.py`:
+
+```python
+"""Direct unit tests for feather_etl.status.load_status()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _make_state_with_runs(state_path: Path) -> None:
+    """Create a state DB and insert run rows for two tables."""
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    sm.init_state()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sm.record_run_start("run-1", "orders", now)
+    sm.record_run_complete("run-1", "success", rows_loaded=10)
+    sm.record_run_start("run-2", "customers", now)
+    sm.record_run_complete("run-2", "success", rows_loaded=5)
+
+
+class TestLoadStatus:
+    def test_returns_rows_for_each_table(self, tmp_path: Path):
+        from feather_etl.status import load_status
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_status(state_path)
+
+        assert {r["table_name"] for r in rows} == {"orders", "customers"}
+
+    def test_returns_empty_list_when_no_runs(self, tmp_path: Path):
+        from feather_etl.state import StateManager
+        from feather_etl.status import load_status
+
+        state_path = tmp_path / "feather_state.duckdb"
+        sm = StateManager(state_path)
+        sm.init_state()
+
+        rows = load_status(state_path)
+
+        assert rows == []
+
+
+class TestLoadStatusPreconditions:
+    def test_raises_state_db_missing_when_no_db(self, tmp_path: Path):
+        from feather_etl.exceptions import StateDBMissingError
+        from feather_etl.status import load_status
+
+        with pytest.raises(StateDBMissingError):
+            load_status(tmp_path / "missing.duckdb")
+```
+
+- [ ] **Step 2.2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_status_core.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feather_etl.status'`.
+
+- [ ] **Step 2.3: Create `status.py`**
+
+Create `src/feather_etl/status.py`:
+
+```python
+"""`feather status` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.exceptions import StateDBMissingError
+
+
+def load_status(state_path: Path) -> list[dict]:
+    """Return per-table last-run status rows from the state DB.
+
+    Raises ``StateDBMissingError`` if the state DB does not exist.
+    """
+    if not state_path.exists():
+        raise StateDBMissingError(str(state_path))
+
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    return sm.get_status()
+```
+
+- [ ] **Step 2.4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_status_core.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 2.5: Rewrite `commands/status.py` as thin wrapper**
+
+Replace `src/feather_etl/commands/status.py` with:
+
+```python
+"""`feather status` command — thin Typer wrapper over feather_etl.status."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from feather_etl.commands._common import (
+    _is_json,
+    _load_and_validate,
+)
+from feather_etl.exceptions import StateDBMissingError
+from feather_etl.output import emit
+from feather_etl.status import load_status
+
+
+def status(
+    ctx: typer.Context, config: Path = typer.Option("feather.yaml", "--config")
+) -> None:
+    """Show last run status for all tables."""
+    cfg = _load_and_validate(config)
+    state_path = cfg.config_dir / "feather_state.duckdb"
+
+    try:
+        rows = load_status(state_path)
+    except StateDBMissingError:
+        typer.echo("No state DB found. Run 'feather setup' first.", err=True)
+        raise typer.Exit(code=1)
+
+    if not rows:
+        if _is_json(ctx):
+            return
+        typer.echo("No runs recorded yet.")
+        return
+
+    if _is_json(ctx):
+        emit(
+            [
+                {
+                    "table_name": row["table_name"],
+                    "last_run_at": str(row.get("ended_at", "")),
+                    "status": row["status"],
+                    "watermark": row.get("watermark"),
+                    "rows_loaded": row.get("rows_loaded"),
+                }
+                for row in rows
+            ],
+            json_mode=True,
+        )
+    else:
+        typer.echo(f"{'Table':<30} {'Status':<12} {'Rows':<10} {'Last Run'}")
+        typer.echo("-" * 75)
+        for row in rows:
+            typer.echo(
+                f"{row['table_name']:<30} {row['status']:<12} "
+                f"{row.get('rows_loaded', '-'):<10} {row.get('ended_at', '-')}"
+            )
+            if row["status"] == "failure" and row.get("error_message"):
+                error = str(row["error_message"])
+                if len(error) > 80:
+                    error = error[:77] + "..."
+                typer.echo(f"  Error: {error}")
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="status")(status)
+```
+
+- [ ] **Step 2.6: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (now ~660).
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/feather_etl/status.py src/feather_etl/commands/status.py \
+        tests/test_status_core.py
+git commit -m "refactor(status): extract pure core into feather_etl.status (#43)
+
+Mirror of Task 1 for the status command. Reuses StateDBMissingError
+from feather_etl.exceptions. The wrapper preserves the exact
+'No state DB found. Run feather setup first.' message and exit code
+from the existing implementation."
+```
+
+---
+
+## Task 3: Add core-module purity test
+
+**Files:**
+- Create: `tests/test_core_module_purity.py`
+
+This task encodes the issue's "no `typer` import in core modules" constraint as an automated, regression-proof test instead of a manual `grep` check. Subsequent tasks add their new module to the parametrize list.
+
+- [ ] **Step 3.1: Write the purity test**
+
+Create `tests/test_core_module_purity.py`:
+
+```python
+"""Purity test: pure-core modules must not import Typer.
+
+The split between `commands/<name>.py` (Typer-aware CLI wrapper) and
+`<name>.py` (pure orchestration) is a load-bearing architectural
+constraint enforced here. If you find yourself wanting to add `typer`
+to a module in this list, the split is wrong — push the Typer concern
+back into the corresponding `commands/<name>.py` wrapper instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+CORE_MODULES = [
+    "feather_etl.pipeline",
+    "feather_etl.cache",
+    "feather_etl.viewer_server",
+    "feather_etl.init_wizard",
+    "feather_etl.exceptions",
+    "feather_etl.history",
+    "feather_etl.status",
+]
+
+
+@pytest.mark.parametrize("module_name", CORE_MODULES)
+def test_core_module_does_not_import_typer(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+    source = inspect.getsource(module)
+    assert "import typer" not in source, (
+        f"{module_name} must not import typer — push the Typer concern "
+        f"into the corresponding commands/<name>.py wrapper."
+    )
+    assert "from typer" not in source, (
+        f"{module_name} must not import from typer — push the Typer concern "
+        f"into the corresponding commands/<name>.py wrapper."
+    )
+```
+
+- [ ] **Step 3.2: Run the purity test**
+
+Run: `uv run pytest tests/test_core_module_purity.py -v`
+Expected: 7 passed.
+
+If `viewer_server` or `init_wizard` fails the test, remove the offending `import typer` / `from typer` line in the same commit. (Confirmed at plan-writing time: neither imports typer, so this should pass cleanly.)
+
+- [ ] **Step 3.3: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (now ~667 — gained 7 parametrized cases).
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add tests/test_core_module_purity.py
+git commit -m "test(core): assert pure-core modules do not import typer (#43)
+
+Encode the issue's 'no typer in <name>.py' constraint as an
+automated parametrized test, replacing the manual grep check in
+the issue's done-when criteria. Initial parametrize list covers all
+existing pure-core modules (pipeline, cache, viewer_server,
+init_wizard, exceptions, history, status). Subsequent refactors
+add their new core module to the list as part of the same commit."
+```
+
+---
+
+## Task 4: Verify `init` is already conformant
+
+**Files:** None modified (verification-only task).
+
+This task confirms that `commands/init.py`'s only non-Typer logic is the project-name prompt and dir-exists guard, and that those belong in the CLI (UX/overwrite-prevention concern, not a scaffolding correctness rule). `init_wizard.scaffold_project()` should remain callable from any context without surprise prompts. The purity test from Task 3 already asserts `init_wizard` has no `typer` import.
+
+- [ ] **Step 4.1: Read `commands/init.py` and `init_wizard.py`**
+
+Open both files. Verify:
+  - `commands/init.py` consists of: optional `typer.prompt` for project name, `Path(...).exists()` check with directory-not-empty check, call to `init_wizard.scaffold_project()`, JSON-or-text output, register function. ~44 lines total.
+  - `init_wizard.py` exposes `scaffold_project(project_path: Path) -> list[str]` with no Typer dependency.
+
+- [ ] **Step 4.2: Decide whether any change is needed**
+
+The dir-exists guard (`if non_hidden: typer.echo(...) raise typer.Exit(1)`) is a UX decision: "don't silently overwrite a non-empty directory." Pushing it into `init_wizard.scaffold_project()` would force a non-CLI caller (future MCP/library) to also raise on non-empty dirs, which is an unwanted policy. **Leave it in the CLI.**
+
+The `typer.prompt` for project name when no positional arg is given is also CLI-only (no equivalent for non-interactive callers). **Leave it in the CLI.**
+
+- [ ] **Step 4.3: Outcome**
+
+- If no tidy-up surfaces (expected outcome based on plan-writing-time review): **skip the commit.** Note in PR description: "Task 4 (init verify): no changes — `commands/init.py` is already a thin wrapper, `init_wizard.scaffold_project()` is already pure, and the dir-exists/prompt logic correctly stays in the CLI as a UX concern."
+- If a tidy-up surfaces during execution, commit it with message `refactor(init): <one-line description> (#43)`.
+
+---
+
+## Task 5: Extract `validate` core
+
+**Files:**
+- Create: `src/feather_etl/validate.py`
+- Create: `tests/test_validate_core.py`
+- Modify: `src/feather_etl/commands/validate.py` (shrink to thin wrapper)
+- Modify: `tests/test_core_module_purity.py` (add `feather_etl.validate` to parametrize list)
+
+- [ ] **Step 5.1: Write failing tests for `run_validate`**
+
+Create `tests/test_validate_core.py`:
+
+```python
+"""Direct unit tests for feather_etl.validate.run_validate()."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+
+
+def _make_sqlite_project(tmp_path: Path, *, valid_path: bool = True) -> Path:
+    """Build a minimal feather project with a SQLite source. Returns config path."""
+    if valid_path:
+        shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+        source_path = "./source.sqlite"
+    else:
+        source_path = "./missing.sqlite"
+
+    config = {
+        "sources": [{"type": "sqlite", "path": source_path}],
+        "destination": {"path": "./feather_data.duckdb"},
+        "tables": [
+            {
+                "name": "orders",
+                "source_table": "orders",
+                "target_table": "bronze.orders",
+                "strategy": "full",
+            }
+        ],
+    }
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(config))
+    return config_path
+
+
+class TestRunValidate:
+    def test_reports_each_source_status_when_all_ok(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+        report = run_validate(cfg)
+
+        assert report.all_ok is True
+        assert report.tables_count == 1
+        assert len(report.sources) == 1
+        assert report.sources[0].type == "sqlite"
+        assert report.sources[0].ok is True
+        assert report.sources[0].error is None
+
+    def test_returns_all_ok_false_when_any_source_check_fails(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path, valid_path=False))
+        report = run_validate(cfg)
+
+        assert report.all_ok is False
+        assert report.sources[0].ok is False
+
+    def test_propagates_last_error_for_failed_sources(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path, valid_path=False))
+        report = run_validate(cfg)
+
+        assert report.sources[0].error is not None
+        assert report.sources[0].error != ""
+
+    def test_label_uses_path_for_file_sources(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+        report = run_validate(cfg)
+
+        # File-based sources expose `path` — the label should be the path.
+        assert "source.sqlite" in str(report.sources[0].label)
+```
+
+- [ ] **Step 5.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_validate_core.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feather_etl.validate'`.
+
+- [ ] **Step 5.3: Create `validate.py`**
+
+Create `src/feather_etl/validate.py`:
+
+```python
+"""`feather validate` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from feather_etl.config import FeatherConfig
+
+
+@dataclass
+class SourceCheckResult:
+    """Connection-check result for a single source."""
+
+    type: str
+    label: str          # path or host, whichever the source exposes; "configured" otherwise
+    ok: bool
+    error: str | None   # source._last_error when ok is False
+
+
+@dataclass
+class ValidateReport:
+    """Result of running `feather validate` against a loaded config."""
+
+    sources: list[SourceCheckResult]
+    tables_count: int
+    all_ok: bool
+
+
+def run_validate(cfg: FeatherConfig) -> ValidateReport:
+    """Test connection for each configured source. Pure read; no side effects."""
+    results: list[SourceCheckResult] = []
+    for source in cfg.sources:
+        ok = source.check()
+        label = (
+            getattr(source, "path", None)
+            or getattr(source, "host", None)
+            or "configured"
+        )
+        error = getattr(source, "_last_error", None) if not ok else None
+        results.append(
+            SourceCheckResult(
+                type=source.type,
+                label=str(label),
+                ok=ok,
+                error=error,
+            )
+        )
+
+    return ValidateReport(
+        sources=results,
+        tables_count=len(cfg.tables),
+        all_ok=all(r.ok for r in results),
+    )
+```
+
+- [ ] **Step 5.4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_validate_core.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 5.5: Rewrite `commands/validate.py` as thin wrapper**
+
+Replace `src/feather_etl/commands/validate.py` with:
+
+```python
+"""`feather validate` command — thin Typer wrapper over feather_etl.validate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from feather_etl.commands._common import (
+    _is_json,
+    _load_and_validate,
+)
+from feather_etl.output import emit_line
+from feather_etl.validate import run_validate
+
+
+def validate(
+    ctx: typer.Context, config: Path = typer.Option("feather.yaml", "--config")
+) -> None:
+    """Validate config, test source connection, and write feather_validation.json."""
+    cfg = _load_and_validate(config)
+
+    report = run_validate(cfg)
+
+    if not _is_json(ctx):
+        for r in report.sources:
+            conn_status = "connected" if r.ok else "FAILED"
+            typer.echo(f"  Source: {r.type} ({r.label}) — {conn_status}")
+            if not r.ok and r.error:
+                typer.echo(f"    Details: {r.error}", err=True)
+
+    if _is_json(ctx):
+        emit_line(
+            {
+                "valid": True,
+                "tables_count": report.tables_count,
+                "source_type": cfg.sources[0].type,
+                "destination": str(cfg.destination.path),
+                "mode": cfg.mode,
+                "source_connected": report.all_ok,
+            },
+            json_mode=True,
+        )
+    else:
+        typer.echo(f"Config valid: {report.tables_count} table(s)")
+        typer.echo(f"  Destination: {cfg.destination.path}")
+        typer.echo(f"  State: {cfg.config_dir / 'feather_state.duckdb'}")
+        for t in cfg.tables:
+            typer.echo(f"  Table: {t.name} → {t.target_table} ({t.strategy})")
+
+    if not report.all_ok:
+        typer.echo("Source connection failed.", err=True)
+        raise typer.Exit(code=2)
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="validate")(validate)
+```
+
+- [ ] **Step 5.6: Add `feather_etl.validate` to the purity test**
+
+Edit `tests/test_core_module_purity.py`. Find the `CORE_MODULES` list and add `"feather_etl.validate"` after `"feather_etl.status"`:
+
+```python
+CORE_MODULES = [
+    "feather_etl.pipeline",
+    "feather_etl.cache",
+    "feather_etl.viewer_server",
+    "feather_etl.init_wizard",
+    "feather_etl.exceptions",
+    "feather_etl.history",
+    "feather_etl.status",
+    "feather_etl.validate",
+]
+```
+
+- [ ] **Step 5.7: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass (now ~671 — gained 4 from `test_validate_core.py` plus 1 new purity case). Specifically check `tests/commands/test_validate.py` is still green — it exercises CLI behavior end-to-end and is the contract for "no behavior change."
+
+- [ ] **Step 5.8: Commit**
+
+```bash
+git add src/feather_etl/validate.py src/feather_etl/commands/validate.py \
+        tests/test_validate_core.py tests/test_core_module_purity.py
+git commit -m "refactor(validate): extract pure core into feather_etl.validate (#43)
+
+First dataclass-shaped core. ValidateReport carries per-source
+connection results, table count, and aggregate all_ok flag. The
+wrapper preserves exact CLI output (per-source connection lines,
+'Config valid: N table(s)' header, 'Source connection failed.'
+error, exit code 2 on failure) and JSON shape.
+
+Added feather_etl.validate to the core-module purity test."
+```
+
+---
+
+## Task 6: Extract `setup` core
+
+**Files:**
+- Create: `src/feather_etl/setup.py`
+- Create: `tests/test_setup_core.py`
+- Modify: `src/feather_etl/commands/setup.py` (shrink to thin wrapper)
+- Modify: `tests/test_core_module_purity.py` (add `feather_etl.setup`)
+
+- [ ] **Step 6.1: Write failing tests for `run_setup`**
+
+Create `tests/test_setup_core.py`:
+
+```python
+"""Direct unit tests for feather_etl.setup.run_setup()."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+
+
+def _make_project(tmp_path: Path, *, mode: str | None = None) -> Path:
+    """Build a minimal feather project. Returns config path."""
+    shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+    config: dict = {
+        "sources": [{"type": "sqlite", "path": "./source.sqlite"}],
+        "destination": {"path": "./feather_data.duckdb"},
+        "tables": [
+            {
+                "name": "orders",
+                "source_table": "orders",
+                "target_table": "bronze.orders",
+                "strategy": "full",
+            }
+        ],
+    }
+    if mode is not None:
+        config["mode"] = mode
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(config))
+    return config_path
+
+
+def _write_silver_transform(tmp_path: Path) -> None:
+    """Write a tiny silver view definition that depends on bronze.orders."""
+    tdir = tmp_path / "transforms" / "silver"
+    tdir.mkdir(parents=True, exist_ok=True)
+    (tdir / "orders_clean.sql").write_text(
+        "CREATE OR REPLACE VIEW silver.orders_clean AS "
+        "SELECT * FROM bronze.orders;\n"
+    )
+
+
+class TestRunSetup:
+    def test_initializes_state_db_and_destination(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        cfg = load_config(_make_project(tmp_path))
+
+        result = run_setup(cfg)
+
+        assert result.state_db_path.exists()
+        assert result.destination_path == cfg.destination.path
+        assert result.transform_results is None  # no transforms in this project
+
+    def test_returns_none_transforms_when_no_transforms_found(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        cfg = load_config(_make_project(tmp_path))
+        result = run_setup(cfg)
+
+        assert result.transform_results is None
+
+    def test_executes_transforms_when_present(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        config_path = _make_project(tmp_path)
+        _write_silver_transform(tmp_path)
+        cfg = load_config(config_path)
+
+        result = run_setup(cfg)
+
+        assert result.transform_results is not None
+        assert len(result.transform_results) >= 1
+        assert any(
+            t.name == "orders_clean" and t.schema == "silver"
+            for t in result.transform_results
+        )
+```
+
+- [ ] **Step 6.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_setup_core.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feather_etl.setup'`.
+
+- [ ] **Step 6.3: Create `setup.py`**
+
+Create `src/feather_etl/setup.py`:
+
+```python
+"""`feather setup` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from feather_etl.config import FeatherConfig
+from feather_etl.transforms import TransformResult
+
+
+@dataclass
+class SetupResult:
+    """Result of running `feather setup` against a loaded config."""
+
+    state_db_path: Path
+    destination_path: Path
+    transform_results: list[TransformResult] | None  # None if no transforms found
+
+
+def run_setup(cfg: FeatherConfig) -> SetupResult:
+    """Initialize state DB, create destination schemas, execute transforms.
+
+    Returns a ``SetupResult`` describing what was created. Transforms are
+    executed if any are discovered in ``<config_dir>/transforms/``. In prod
+    mode, only gold transforms are executed; in dev mode, all transforms are
+    executed with ``force_views=True`` (matches the prior CLI behavior).
+    """
+    from feather_etl.destinations.duckdb import DuckDBDestination
+    from feather_etl.state import StateManager
+    from feather_etl.transforms import (
+        build_execution_order,
+        discover_transforms,
+        execute_transforms,
+    )
+
+    state_path = cfg.config_dir / "feather_state.duckdb"
+    sm = StateManager(state_path)
+    sm.init_state()
+
+    dest = DuckDBDestination(path=cfg.destination.path)
+    dest.setup_schemas()
+
+    transform_results: list[TransformResult] | None = None
+    transforms = discover_transforms(cfg.config_dir)
+    if transforms:
+        ordered = build_execution_order(transforms)
+        con = dest._connect()
+        try:
+            if cfg.mode == "prod":
+                gold_only = [t for t in ordered if t.schema == "gold"]
+                transform_results = execute_transforms(con, gold_only)
+            else:
+                transform_results = execute_transforms(con, ordered, force_views=True)
+        finally:
+            con.close()
+
+    return SetupResult(
+        state_db_path=state_path,
+        destination_path=cfg.destination.path,
+        transform_results=transform_results,
+    )
+```
+
+- [ ] **Step 6.4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/test_setup_core.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 6.5: Rewrite `commands/setup.py` as thin wrapper**
+
+Replace `src/feather_etl/commands/setup.py` with:
+
+```python
+"""`feather setup` command — thin Typer wrapper over feather_etl.setup."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import typer
+
+from feather_etl.commands._common import (
+    _is_json,
+    _load_and_validate,
+)
+from feather_etl.output import emit_line
+from feather_etl.setup import run_setup
+
+
+def setup(
+    ctx: typer.Context,
+    config: Path = typer.Option("feather.yaml", "--config"),
+    mode: str | None = typer.Option(None, "--mode"),
+) -> None:
+    """Preview and initialize state DB and schemas. Optional — feather run creates them automatically."""
+    cfg = _load_and_validate(config, mode_override=mode)
+    if not _is_json(ctx):
+        typer.echo(f"Mode: {cfg.mode}")
+
+    result = run_setup(cfg)
+
+    if not _is_json(ctx):
+        typer.echo(f"State DB initialized: {result.state_db_path}")
+        typer.echo(f"Schemas created in: {result.destination_path}")
+
+    transforms_applied = 0
+    if result.transform_results is not None:
+        results = result.transform_results
+        transforms_applied = sum(1 for r in results if r.status == "success")
+
+        if not _is_json(ctx):
+            silver_views = sum(
+                1 for r in results if r.schema == "silver" and r.status == "success"
+            )
+            gold_views = sum(
+                1
+                for r in results
+                if r.schema == "gold" and r.type == "view" and r.status == "success"
+            )
+            gold_tables = sum(
+                1
+                for r in results
+                if r.schema == "gold" and r.type == "table" and r.status == "success"
+            )
+            parts = []
+            if silver_views:
+                parts.append(f"{silver_views} silver view(s)")
+            if gold_views:
+                parts.append(f"{gold_views} gold view(s)")
+            if gold_tables:
+                parts.append(f"{gold_tables} gold table(s)")
+            typer.echo(f"Transforms applied: {', '.join(parts)}")
+
+            errors = [r for r in results if r.status == "error"]
+            for r in errors:
+                typer.echo(
+                    f"  Transform error: {r.schema}.{r.name} — {r.error}", err=True
+                )
+
+    if _is_json(ctx):
+        emit_line(
+            {
+                "state_db": str(result.state_db_path),
+                "destination": str(result.destination_path),
+                "schemas_created": True,
+                "transforms_applied": transforms_applied,
+            },
+            json_mode=True,
+        )
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="setup")(setup)
+```
+
+- [ ] **Step 6.6: Add `feather_etl.setup` to the purity test**
+
+Edit `tests/test_core_module_purity.py`. Add `"feather_etl.setup"` to `CORE_MODULES`.
+
+- [ ] **Step 6.7: Run full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass. Specifically check `tests/commands/test_setup.py` is still green.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add src/feather_etl/setup.py src/feather_etl/commands/setup.py \
+        tests/test_setup_core.py tests/test_core_module_purity.py
+git commit -m "refactor(setup): extract pure core into feather_etl.setup (#43)
+
+SetupResult carries the state DB path, destination path, and
+optional transform results. The wrapper preserves the exact CLI
+output (Mode line, State DB initialized, Schemas created in,
+Transforms applied summary, per-error lines) and JSON shape
+including transforms_applied count.
+
+Mode-aware transform execution preserved exactly: prod mode runs
+gold-only; dev mode runs all transforms with force_views=True.
+
+Added feather_etl.setup to the core-module purity test."
+```
+
+---
+
+## Task 7: Extract `discover` core (the big one)
+
+**Files:**
+- Create: `src/feather_etl/discover.py`
+- Create: `tests/test_discover_core.py`
+- Modify: `src/feather_etl/commands/discover.py` (shrink to thin wrapper)
+- Modify: `tests/test_core_module_purity.py` (add `feather_etl.discover`)
+
+The discover refactor splits into three pure top-level functions: `detect_renames_for_sources`, `apply_rename_decision`, `run_discover`. The CLI wrapper computes the rename decision interactively (using `typer.confirm` and the `--yes`/`--no-renames` flags) and passes pre-resolved values to `apply_rename_decision`. The core never imports `typer`, never touches stdin, and never calls `serve_and_open` (that's the CLI's job, after `run_discover` returns).
+
+- [ ] **Step 7.1: Write failing tests for `detect_renames_for_sources`**
+
+Create `tests/test_discover_core.py`. Start with the rename-detection tests:
+
+```python
+"""Direct unit tests for feather_etl.discover top-level functions."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+
+
+def _make_sqlite_project(tmp_path: Path, source_name: str | None = None) -> Path:
+    """Set up a tmp SQLite feather project. Returns config path."""
+    shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+    source: dict = {"type": "sqlite", "path": "./source.sqlite"}
+    if source_name is not None:
+        source["name"] = source_name
+    cfg = {
+        "sources": [source],
+        "destination": {"path": "./feather_data.duckdb"},
+        "tables": [
+            {
+                "name": "orders",
+                "source_table": "orders",
+                "target_table": "bronze.orders",
+                "strategy": "full",
+            }
+        ],
+    }
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(cfg))
+    return config_path
+
+
+class TestDetectRenamesForSources:
+    def test_returns_empty_proposals_when_state_is_empty(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == []
+        assert detection.ambiguous == []
+
+    def test_finds_rename_when_fingerprint_matches_under_new_name(
+        self, tmp_path: Path
+    ):
+        """Rename a source in YAML; same fingerprint → proposal."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        # First load with name "old_db" — record state.
+        config_path = _make_sqlite_project(tmp_path, source_name="old_db")
+        cfg = load_config(config_path)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        # Simulate a prior successful discover under "old_db".
+        from feather_etl.discover import _fingerprint_for
+
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=_fingerprint_for(sources[0]),
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_db.json",
+        )
+
+        # Now rename source to "new_db".
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path)
+        sources = expand_db_sources(cfg.sources)
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == [("old_db", "new_db")]
+        assert detection.ambiguous == []
+```
+
+- [ ] **Step 7.2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/test_discover_core.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'feather_etl.discover'`.
+
+- [ ] **Step 7.3: Create `discover.py` skeleton — dataclasses + helpers + `detect_renames_for_sources`**
+
+Create `src/feather_etl/discover.py`:
+
+```python
+"""`feather discover` core — orchestration without Typer.
+
+Three pure top-level functions:
+
+* ``detect_renames_for_sources(state, sources) -> RenameDetection``
+  Pure detection. Returns proposals + ambiguous list. No I/O.
+
+* ``apply_rename_decision(state, accepted, rejected, sources, config_dir) -> None``
+  Applies a pre-resolved decision. The CLI wrapper resolves the decision
+  interactively (typer.confirm + --yes / --no-renames) and calls this.
+
+* ``run_discover(cfg, config_dir, *, refresh, retry_failed, prune) -> DiscoverReport``
+  Per-source discovery loop. Assumes renames already resolved.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from feather_etl.config import FeatherConfig, schema_output_path
+from feather_etl.discover_state import (
+    DiscoverState,
+    apply_renames,
+    classify,
+    detect_renames,
+)
+
+
+@dataclass
+class RenameDetection:
+    """Output of ``detect_renames_for_sources``."""
+
+    proposals: list[tuple[str, str]] = field(default_factory=list)
+    ambiguous: list[tuple[str, list[str]]] = field(default_factory=list)
+
+
+@dataclass
+class SourceDiscoveryResult:
+    """One source's outcome from ``run_discover``."""
+
+    name: str
+    decision: str       # "new" | "retry" | "rerun" | "cached" | "skip" | "removed"
+    status: str         # "succeeded" | "failed" | "cached" | "skipped" | "pruned"
+    table_count: int = 0
+    output_path: Path | None = None
+    error: str | None = None
+
+
+@dataclass
+class DiscoverReport:
+    """Aggregate result of ``run_discover``."""
+
+    results: list[SourceDiscoveryResult] = field(default_factory=list)
+    succeeded_count: int = 0
+    failed_count: int = 0
+    cached_count: int = 0
+    pruned_count: int = 0
+    state_last_run_at: str | None = None
+
+
+def _write_schema(source, target_dir: Path) -> tuple[Path, int]:
+    """Discover ``source`` and write its schema JSON. Returns (path, table_count)."""
+    schemas = source.discover()
+    payload = [
+        {
+            "table_name": s.name,
+            "columns": [{"name": c[0], "type": c[1]} for c in s.columns],
+        }
+        for s in schemas
+    ]
+    out = target_dir / schema_output_path(source)
+    out.write_text(json.dumps(payload, indent=2))
+    return out, len(schemas)
+
+
+def _fingerprint_for(source) -> str:
+    """Composition per spec §6.7.
+
+    DB sources: '<type>:<host>:<port>:<database>'. File sources: '<type>:<absolute_path>'.
+    """
+    if hasattr(source, "host") and source.host is not None:
+        return (
+            f"{source.type}:{source.host}:{source.port or ''}:{source.database or ''}"
+        )
+    return f"{source.type}:{Path(source.path).resolve()}"
+
+
+def detect_renames_for_sources(
+    state: DiscoverState,
+    sources: list,
+) -> RenameDetection:
+    """Pure detection. Returns proposals + ambiguous list. No I/O, no prompts."""
+    current_pairs = [(source.name, _fingerprint_for(source)) for source in sources]
+    proposals, ambiguous = detect_renames(state=state, current=current_pairs)
+    return RenameDetection(proposals=list(proposals), ambiguous=list(ambiguous))
+```
+
+- [ ] **Step 7.4: Run rename-detection tests to verify they pass**
+
+Run: `uv run pytest tests/test_discover_core.py::TestDetectRenamesForSources -v`
+Expected: 2 passed.
+
+- [ ] **Step 7.5: Add ambiguous-rename test, then run**
+
+Append to `tests/test_discover_core.py` inside `TestDetectRenamesForSources`:
+
+```python
+    def test_returns_ambiguous_when_multiple_state_entries_match(
+        self, tmp_path: Path
+    ):
+        """Two stale state entries with the same fingerprint as one current
+        source → ambiguous (cannot decide which old name was renamed)."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import _fingerprint_for, detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        state.record_ok(
+            name="old_a",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_a.json",
+        )
+        state.record_ok(
+            name="old_b",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_b.json",
+        )
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == []
+        assert len(detection.ambiguous) == 1
+        new_name, candidates = detection.ambiguous[0]
+        assert new_name == "new_db"
+        assert set(candidates) == {"old_a", "old_b"}
+```
+
+Run: `uv run pytest tests/test_discover_core.py::TestDetectRenamesForSources -v`
+Expected: 3 passed.
+
+- [ ] **Step 7.6: Write failing tests for `apply_rename_decision`**
+
+Append to `tests/test_discover_core.py`:
+
+```python
+class TestApplyRenameDecision:
+    def test_renames_state_and_files_for_accepted_proposals(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import (
+            _fingerprint_for,
+            apply_rename_decision,
+        )
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        old_path = tmp_path / "schemas-sqlite-old_db.json"
+        old_path.write_text("[]")
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=old_path,
+        )
+
+        apply_rename_decision(
+            state,
+            accepted=[("old_db", "new_db")],
+            rejected=[],
+            sources=sources,
+            config_dir=tmp_path,
+        )
+
+        assert "new_db" in state.sources
+        assert "old_db" not in state.sources
+
+    def test_marks_orphaned_for_rejected_proposals(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import _fingerprint_for, apply_rename_decision
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_db.json",
+        )
+
+        apply_rename_decision(
+            state,
+            accepted=[],
+            rejected=[("old_db", "new_db")],
+            sources=sources,
+            config_dir=tmp_path,
+        )
+
+        assert state.sources["old_db"].get("status") == "orphaned"
+```
+
+- [ ] **Step 7.7: Run apply-rename tests — verify they fail**
+
+Run: `uv run pytest tests/test_discover_core.py::TestApplyRenameDecision -v`
+Expected: FAIL with `AttributeError` or `ImportError` for `apply_rename_decision` (not yet defined).
+
+- [ ] **Step 7.8: Add `apply_rename_decision` to `discover.py`**
+
+Append to `src/feather_etl/discover.py`:
+
+```python
+def apply_rename_decision(
+    state: DiscoverState,
+    accepted: list[tuple[str, str]],
+    rejected: list[tuple[str, str]],
+    sources: list,
+    config_dir: Path,
+) -> None:
+    """Apply a pre-resolved rename decision.
+
+    ``accepted`` proposals are applied via ``apply_renames`` (state + files
+    are renamed). ``rejected`` proposals are recorded as orphaned (the new
+    name is treated as a fresh source on the next discovery pass).
+    """
+    if accepted:
+        apply_renames(
+            state=state,
+            renames=accepted,
+            config_dir=config_dir,
+            sources=sources,
+        )
+    for old_name, new_name in rejected:
+        state.record_orphaned(
+            old_name,
+            note=f"rename rejected; new source discovered as {new_name}",
+        )
+```
+
+- [ ] **Step 7.9: Run apply-rename tests — verify they pass**
+
+Run: `uv run pytest tests/test_discover_core.py::TestApplyRenameDecision -v`
+Expected: 2 passed.
+
+- [ ] **Step 7.10: Write failing tests for `run_discover`**
+
+Append to `tests/test_discover_core.py`:
+
+```python
+class TestRunDiscover:
+    def test_records_succeeded_sources_with_table_counts(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        report = run_discover(
+            cfg,
+            tmp_path,
+            refresh=False,
+            retry_failed=False,
+            prune=False,
+        )
+
+        assert report.succeeded_count == 1
+        assert report.failed_count == 0
+        assert len(report.results) == 1
+        r = report.results[0]
+        assert r.status == "succeeded"
+        assert r.table_count > 0
+        assert r.output_path is not None
+        assert r.output_path.exists()
+
+    def test_records_failed_sources_with_error_message(self, tmp_path: Path):
+        """Source pointing at a missing file → failed, error captured in result."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        # Build config with a deliberately missing SQLite file.
+        cfg_dict = {
+            "sources": [{"type": "sqlite", "path": "./missing.sqlite"}],
+            "destination": {"path": "./feather_data.duckdb"},
+            "tables": [
+                {
+                    "name": "orders",
+                    "source_table": "orders",
+                    "target_table": "bronze.orders",
+                    "strategy": "full",
+                }
+            ],
+        }
+        config_path = tmp_path / "feather.yaml"
+        config_path.write_text(yaml.dump(cfg_dict))
+        # discover_mode skips table validation
+        cfg = load_config(config_path, validate=False)
+
+        report = run_discover(
+            cfg,
+            tmp_path,
+            refresh=False,
+            retry_failed=False,
+            prune=False,
+        )
+
+        assert report.failed_count == 1
+        assert report.succeeded_count == 0
+        assert report.results[0].status == "failed"
+        assert report.results[0].error is not None
+
+    def test_with_refresh_ignores_cached_state(self, tmp_path: Path):
+        """A second run with refresh=True re-discovers a previously-discovered source."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        # First run — establishes state.
+        run_discover(cfg, tmp_path, refresh=False, retry_failed=False, prune=False)
+
+        # Second run with refresh — should re-discover, not return cached.
+        report = run_discover(
+            cfg, tmp_path, refresh=True, retry_failed=False, prune=False
+        )
+
+        assert report.succeeded_count == 1
+        assert report.cached_count == 0
+
+    def test_second_run_without_refresh_reports_cached(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        run_discover(cfg, tmp_path, refresh=False, retry_failed=False, prune=False)
+        report = run_discover(
+            cfg, tmp_path, refresh=False, retry_failed=False, prune=False
+        )
+
+        assert report.cached_count == 1
+        assert report.succeeded_count == 0
+
+    def test_with_prune_removes_state_and_files_for_removed_sources(
+        self, tmp_path: Path
+    ):
+        from feather_etl.config import load_config
+        from feather_etl.discover import _fingerprint_for, run_discover
+        from feather_etl.discover_state import DiscoverState
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        # Seed a state entry for a now-removed source with a file on disk.
+        state = DiscoverState.load(tmp_path)
+        old_path = tmp_path / "schemas-sqlite-stale.json"
+        old_path.write_text("[]")
+        state.record_ok(
+            name="stale",
+            type_="sqlite",
+            fingerprint="sqlite:/non/existent",
+            table_count=1,
+            output_path=old_path,
+        )
+        state.save()
+
+        report = run_discover(
+            cfg, tmp_path, refresh=False, retry_failed=False, prune=True
+        )
+
+        assert report.pruned_count >= 1
+        assert not old_path.exists()
+
+        state = DiscoverState.load(tmp_path)
+        assert "stale" not in state.sources
+```
+
+- [ ] **Step 7.11: Run `run_discover` tests — verify they fail**
+
+Run: `uv run pytest tests/test_discover_core.py::TestRunDiscover -v`
+Expected: FAIL with `AttributeError` or `ImportError` for `run_discover` (not yet defined).
+
+- [ ] **Step 7.12: Add `run_discover` to `discover.py`**
+
+Append to `src/feather_etl/discover.py`:
+
+```python
+def run_discover(
+    cfg: FeatherConfig,
+    config_dir: Path,
+    *,
+    refresh: bool,
+    retry_failed: bool,
+    prune: bool,
+) -> DiscoverReport:
+    """Per-source discovery loop. Assumes renames already resolved.
+
+    The CLI wrapper is responsible for:
+      * resolving rename proposals (interactive or via --yes / --no-renames)
+        and calling ``apply_rename_decision`` before invoking this function;
+      * exiting with code 2 on ambiguous renames (using ``RenameDetection``);
+      * calling ``serve_and_open`` after this function returns.
+    """
+    from feather_etl.sources.expand import expand_db_sources
+
+    state = DiscoverState.load(config_dir)
+    sources = expand_db_sources(cfg.sources)
+
+    flag: str | None = None
+    if refresh:
+        flag = "refresh"
+    elif retry_failed:
+        flag = "retry-failed"
+    elif prune:
+        flag = "prune"
+
+    names = [s.name for s in sources]
+    decisions = classify(state=state, current_names=names, flag=flag)
+
+    report = DiscoverReport(state_last_run_at=state.last_run_at)
+
+    if flag == "prune":
+        for name, dec in list(decisions.items()):
+            entry = state.sources.get(name)
+            if dec == "removed" or (
+                entry and entry.get("status") in ("orphaned", "removed")
+            ):
+                if entry and entry.get("output_path"):
+                    target = config_dir / Path(entry["output_path"]).name
+                    if target.is_file():
+                        target.unlink()
+                state.sources.pop(name, None)
+                report.pruned_count += 1
+                report.results.append(
+                    SourceDiscoveryResult(
+                        name=name, decision=dec, status="pruned"
+                    )
+                )
+        state.save()
+        return report
+
+    for source in sources:
+        decision = decisions.get(source.name, "new")
+        fingerprint = _fingerprint_for(source)
+
+        if decision == "cached":
+            entry = state.sources[source.name]
+            report.cached_count += 1
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="cached",
+                    table_count=entry.get("table_count", 0),
+                )
+            )
+            continue
+        if decision == "skip":
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name, decision=decision, status="skipped"
+                )
+            )
+            continue
+
+        # Source came from expand_db_sources with a pre-set error.
+        if hasattr(source, "_last_error") and source._last_error:
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=source._last_error,
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="failed",
+                    error=source._last_error,
+                )
+            )
+            continue
+
+        if not source.check():
+            err = getattr(source, "_last_error", "connection failed")
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=err,
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name, decision=decision, status="failed", error=err
+                )
+            )
+            continue
+
+        try:
+            out, count = _write_schema(source, config_dir)
+        except Exception as e:  # noqa: BLE001 — preserve existing broad-catch behavior
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=str(e),
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="failed",
+                    error=str(e),
+                )
+            )
+            continue
+
+        report.succeeded_count += 1
+        state.record_ok(
+            name=source.name,
+            type_=source.type,
+            fingerprint=fingerprint,
+            table_count=count,
+            output_path=out,
+            host=getattr(source, "host", None),
+            database=getattr(source, "database", None),
+        )
+        report.results.append(
+            SourceDiscoveryResult(
+                name=source.name,
+                decision=decision,
+                status="succeeded",
+                table_count=count,
+                output_path=out,
+            )
+        )
+
+    # Mark state-only entries as removed (preserves prior CLI behavior).
+    for name, dec in decisions.items():
+        if dec == "removed" and state.sources.get(name, {}).get("status") != "orphaned":
+            state.record_removed(name)
+
+    state.save()
+    return report
+```
+
+- [ ] **Step 7.13: Run `run_discover` tests — verify they pass**
+
+Run: `uv run pytest tests/test_discover_core.py::TestRunDiscover -v`
+Expected: 5 passed.
+
+- [ ] **Step 7.14: Run all discover-core tests together**
+
+Run: `uv run pytest tests/test_discover_core.py -v`
+Expected: 10 passed (3 detection + 2 apply-rename + 5 run_discover).
+
+- [ ] **Step 7.15: Rewrite `commands/discover.py` as thin wrapper**
+
+Replace `src/feather_etl/commands/discover.py` with:
+
+```python
+"""`feather discover` command — thin Typer wrapper over feather_etl.discover."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+
+from feather_etl.commands._common import _load_and_validate
+from feather_etl.discover import (
+    apply_rename_decision,
+    detect_renames_for_sources,
+    run_discover,
+)
+from feather_etl.discover_state import DiscoverState
+from feather_etl.sources.expand import expand_db_sources
+from feather_etl.viewer_server import serve_and_open
+
+
+def _resolve_rename_decision(
+    proposals: list[tuple[str, str]],
+    *,
+    yes: bool,
+    no_renames: bool,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Echo proposals and resolve --yes / --no-renames / TTY confirm.
+
+    Returns ``(accepted, rejected)``. May raise ``typer.Exit(3)`` if the
+    decision is required but stdin is not a TTY.
+    """
+    proposal_err = not sys.stdin.isatty()
+    for old_name, new_name in proposals:
+        typer.echo(
+            f"  Rename inferred: {old_name} -> {new_name}",
+            err=proposal_err,
+        )
+
+    if no_renames:
+        for old_name, new_name in proposals:
+            typer.echo(f"  Kept {old_name} orphaned; treating {new_name} as new")
+        return [], list(proposals)
+
+    if yes:
+        return list(proposals), []
+
+    if sys.stdin.isatty():
+        if typer.confirm("Accept all?", default=True):
+            return list(proposals), []
+        for old_name, new_name in proposals:
+            typer.echo(f"  Kept {old_name} orphaned; treating {new_name} as new")
+        return [], list(proposals)
+
+    typer.echo(
+        "Rename confirmation required in non-interactive mode. "
+        "Re-run with --yes to accept or --no-renames to reject.",
+        err=True,
+    )
+    raise typer.Exit(code=3)
+
+
+def discover(
+    config: Path = typer.Option("feather.yaml", "--config"),
+    refresh: bool = typer.Option(
+        False,
+        "--refresh",
+        help="Re-run discovery for every source, ignoring cached state.",
+    ),
+    retry_failed: bool = typer.Option(
+        False, "--retry-failed", help="Only retry sources that previously failed."
+    ),
+    prune: bool = typer.Option(
+        False,
+        "--prune",
+        help="Delete state entries and JSON files for removed/orphaned sources.",
+    ),
+    yes: bool = typer.Option(False, "--yes", help="Auto-accept inferred renames."),
+    no_renames: bool = typer.Option(
+        False,
+        "--no-renames",
+        help="Reject inferred renames; old entries become orphaned.",
+    ),
+) -> None:
+    """Save each source's schema to an auto-named schema JSON file, then serve/open the schema viewer."""
+    cfg = _load_and_validate(config, discover_mode=True)
+    target_dir = Path(".")
+
+    # Rename phase (only when not in refresh/prune mode — preserves prior behavior).
+    if not (refresh or prune):
+        state = DiscoverState.load(target_dir)
+        sources = expand_db_sources(cfg.sources)
+        detection = detect_renames_for_sources(state, sources)
+
+        if detection.ambiguous:
+            for new_name, candidates in detection.ambiguous:
+                typer.echo(
+                    f"Ambiguous rename for {new_name}: candidates "
+                    f"{', '.join(candidates)}",
+                    err=True,
+                )
+            raise typer.Exit(code=2)
+
+        if detection.proposals:
+            accepted, rejected = _resolve_rename_decision(
+                detection.proposals, yes=yes, no_renames=no_renames
+            )
+            apply_rename_decision(
+                state, accepted=accepted, rejected=rejected,
+                sources=sources, config_dir=target_dir,
+            )
+            state.save()
+
+    # Header line — match prior CLI exactly.
+    state = DiscoverState.load(target_dir)
+    if state.last_run_at:
+        typer.echo(
+            f"Discovering from {config.name} (state file found, "
+            f"last run {state.last_run_at})..."
+        )
+    else:
+        typer.echo(f"Discovering from {config.name}...")
+
+    report = run_discover(
+        cfg, target_dir,
+        refresh=refresh, retry_failed=retry_failed, prune=prune,
+    )
+
+    # Per-source line output (match prior format).
+    if prune:
+        for r in report.results:
+            if r.status == "pruned":
+                # Find the file name to echo (matches "Pruned: <name>" prior format).
+                # When state had output_path the file existed and was deleted.
+                # Reconstruct from convention; fall back to source name.
+                pass
+        # Replicate the prior summary line exactly.
+        typer.echo(f"\nPruned {report.pruned_count} removed/orphaned entries.")
+        return
+
+    total = len(report.results)
+    for idx, r in enumerate(report.results, start=1):
+        prefix = f"  [{idx}/{total}] {r.name}"
+        if r.status == "cached":
+            typer.echo(f"{prefix}  (cached, {r.table_count} tables)")
+        elif r.status == "skipped":
+            typer.echo(f"{prefix}  (skipped)")
+        elif r.status == "failed":
+            typer.echo(f"{prefix}  → FAILED: {r.error}", err=True)
+        elif r.status == "succeeded":
+            assert r.output_path is not None
+            typer.echo(
+                f"{prefix}  ({r.decision})  → {r.table_count} tables → ./{r.output_path.name}"
+            )
+
+    parts: list[str] = []
+    if report.succeeded_count:
+        parts.append(f"{report.succeeded_count} discovered")
+    if report.cached_count:
+        parts.append(f"{report.cached_count} cached")
+    if report.failed_count:
+        parts.append(f"{report.failed_count} failed")
+    typer.echo(f"\n{', '.join(parts)}.")
+
+    serve_and_open(target_dir.resolve(), preferred_port=8000)
+    if report.failed_count > 0:
+        raise typer.Exit(code=2)
+
+
+def register(app: typer.Typer) -> None:
+    app.command(name="discover")(discover)
+```
+
+- [ ] **Step 7.16: Fix the prune-output format to match prior CLI**
+
+The prior CLI emitted `  Pruned: <output_filename>` per pruned file (when the file existed). The thin wrapper as written above has a placeholder `pass` for that. Replace the prune-output block with code that re-derives the filename from `DiscoverState` after `run_discover` returns:
+
+- [ ] Edit `src/feather_etl/commands/discover.py`. Find the `if prune:` block in `discover()` and replace it with:
+
+```python
+    if prune:
+        # Re-read state to find the output_paths that were just removed.
+        # run_discover already deleted the files; we replay names for echo.
+        # The simpler approach: emit "Pruned: <name>" using the names from results.
+        for r in report.results:
+            if r.status == "pruned":
+                typer.echo(f"  Pruned: {r.name}")
+        typer.echo(f"\nPruned {report.pruned_count} removed/orphaned entries.")
+        return
+```
+
+If the existing CLI test in `tests/commands/test_discover.py` asserts the exact `Pruned: <filename>.json` format (including the schema filename), `run_discover` must populate `SourceDiscoveryResult.output_path` for pruned entries too. Check the test; if it requires the filename:
+
+- [ ] Edit `src/feather_etl/discover.py`. In the `if flag == "prune":` block of `run_discover`, set the result's `output_path` from the deleted file:
+
+```python
+            if dec == "removed" or (
+                entry and entry.get("status") in ("orphaned", "removed")
+            ):
+                output_path = None
+                if entry and entry.get("output_path"):
+                    target = config_dir / Path(entry["output_path"]).name
+                    output_path = target
+                    if target.is_file():
+                        target.unlink()
+                state.sources.pop(name, None)
+                report.pruned_count += 1
+                report.results.append(
+                    SourceDiscoveryResult(
+                        name=name, decision=dec, status="pruned",
+                        output_path=output_path,
+                    )
+                )
+```
+
+And update the wrapper's prune-output block to:
+
+```python
+    if prune:
+        for r in report.results:
+            if r.status == "pruned" and r.output_path is not None:
+                typer.echo(f"  Pruned: {r.output_path.name}")
+        typer.echo(f"\nPruned {report.pruned_count} removed/orphaned entries.")
+        return
+```
+
+- [ ] **Step 7.17: Add `feather_etl.discover` to the purity test**
+
+Edit `tests/test_core_module_purity.py`. Add `"feather_etl.discover"` to `CORE_MODULES`.
+
+- [ ] **Step 7.18: Run the full discover test suite (CLI + core)**
+
+Run: `uv run pytest tests/test_discover_core.py tests/commands/test_discover.py tests/commands/test_discover_multi_source.py tests/commands/test_multi_source_guard.py -v`
+Expected: all pass. The CLI tests are the contract for "no behavior change."
+
+If any CLI test fails because of an output-format mismatch, fix the wrapper's formatter — never change the test (it's the contract). Walk the diff line-by-line against the original `commands/discover.py` to spot the missed wording.
+
+- [ ] **Step 7.19: Run the full test suite**
+
+Run: `uv run pytest -q`
+Expected: all tests pass.
+
+- [ ] **Step 7.20: Run the hands-on integration suite**
+
+Run: `bash scripts/hands_on_test.sh`
+Expected: all 61 checks pass.
+
+- [ ] **Step 7.21: Final purity grep (matches the issue's done-when criterion)**
+
+Run:
+```bash
+for f in discover setup validate status history; do
+  if grep -q "typer" "src/feather_etl/$f.py"; then
+    echo "$f: HAS TYPER ✗"; exit 1
+  else
+    echo "$f: pure ✓"
+  fi
+done
+```
+Expected: five "pure ✓" lines.
+
+- [ ] **Step 7.22: Commit**
+
+```bash
+git add src/feather_etl/discover.py src/feather_etl/commands/discover.py \
+        tests/test_discover_core.py tests/test_core_module_purity.py
+git commit -m "refactor(discover): extract pure core into feather_etl.discover (#43)
+
+Split commands/discover.py (274 lines, mixed concerns) into a thin
+Typer wrapper (~120 lines) that delegates to three pure top-level
+functions in feather_etl.discover:
+
+* detect_renames_for_sources(state, sources) -> RenameDetection
+* apply_rename_decision(state, accepted, rejected, sources, config_dir)
+* run_discover(cfg, config_dir, *, refresh, retry_failed, prune)
+    -> DiscoverReport
+
+The CLI wrapper resolves the rename decision (typer.confirm + --yes /
+--no-renames + TTY detection), echoes proposals, calls
+apply_rename_decision with pre-resolved values, then invokes
+run_discover. The viewer (serve_and_open) is started by the wrapper
+after run_discover returns — the core never imports typer or touches
+stdin.
+
+Behavior preserved exactly: rename interaction, ambiguous-exit-2,
+non-interactive-exit-3, per-source line format, summary line, prune
+output, viewer launch, exit-2-on-failure. Verified by the existing
+CLI test suites (tests/commands/test_discover.py,
+test_discover_multi_source.py, test_multi_source_guard.py) plus 10
+new direct unit tests in tests/test_discover_core.py.
+
+Added feather_etl.discover to the core-module purity test."
+```
+
+---
+
+## Done Signal
+
+Run the full validation sequence and confirm all green:
+
+```bash
+uv run pytest -q && \
+bash scripts/hands_on_test.sh && \
+for f in discover setup validate status history; do
+  grep -q typer "src/feather_etl/$f.py" && \
+    { echo "$f: HAS TYPER ✗"; exit 1; } || echo "$f: pure ✓"
+done && \
+uv run pytest -q tests/test_core_module_purity.py tests/test_history_core.py \
+  tests/test_status_core.py tests/test_validate_core.py \
+  tests/test_setup_core.py tests/test_discover_core.py -v
+```
+
+Expected:
+- `pytest -q`: all tests pass (~677 — 653 baseline + 4 history + 3 status + 7 purity + 4 validate + 3 setup + 10 discover; minor variance acceptable).
+- `bash scripts/hands_on_test.sh`: all 61 checks pass.
+- All five `pure ✓` lines.
+- The targeted re-run of new tests shows them green and grouped under their respective files.
+
+Bonus invariant for code review:
+```bash
+git log --oneline feat/thin-cli-refactor ^main
+```
+Expected: 6 or 7 commits (one per task; Task 4 may be skipped if no tidy-up surfaced), each scoped to one command.
+
+---
+
+## Out of Scope (do not do these in this plan)
+
+- Adding features or new CLI flags.
+- Changing the CLI surface — every command's `--flag` list and output stays identical.
+- Touching `pipeline.py`, `cache.py`, `_common.py`, `state.py`, `config.py`, `init_wizard.py`, `viewer_server.py`, or `output.py` beyond pure imports. Exception: removing an unexpected `typer` import in `viewer_server.py` or `init_wizard.py` if Task 3 surfaces one.
+- Refactoring `cache.py` or `commands/cache.py` (already conformant).
+- Issue #40 (retiring `scripts/hands_on_test.sh`) — independent.
+- Issue #15 follow-ups — independent.
+- Performance optimizations.
+- Adding type annotations beyond what the cores need to declare their public API.

--- a/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
+++ b/docs/superpowers/plans/2026-04-19-thin-cli-refactor.md
@@ -657,10 +657,16 @@ from pathlib import Path
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 def _make_sqlite_project(tmp_path: Path, *, valid_path: bool = True) -> Path:
-    """Build a minimal feather project with a SQLite source. Returns config path."""
+    """Build a minimal feather project with a SQLite source. Returns config path.
+
+    Note: ``load_config`` reads tables from ``discovery/curation.json``, not from
+    the YAML, so the project layout uses ``write_curation`` (the same pattern as
+    ``tests/commands/conftest.py::cli_env``).
+    """
     if valid_path:
         shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
         source_path = "./source.sqlite"
@@ -668,19 +674,15 @@ def _make_sqlite_project(tmp_path: Path, *, valid_path: bool = True) -> Path:
         source_path = "./missing.sqlite"
 
     config = {
-        "sources": [{"type": "sqlite", "path": source_path}],
+        "sources": [{"type": "sqlite", "name": "erp", "path": source_path}],
         "destination": {"path": "./feather_data.duckdb"},
-        "tables": [
-            {
-                "name": "orders",
-                "source_table": "orders",
-                "target_table": "bronze.orders",
-                "strategy": "full",
-            }
-        ],
     }
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "orders", "orders")],
+    )
     return config_path
 
 
@@ -710,14 +712,31 @@ class TestRunValidate:
         assert report.sources[0].ok is False
 
     def test_propagates_last_error_for_failed_sources(self, tmp_path: Path):
+        """File sources (sqlite, csv, etc.) don't populate `_last_error` —
+        only DB sources do. Substitute a fake source whose `check()` returns
+        False with a deterministic `_last_error`, mirroring the pattern in
+        `tests/commands/test_validate.py::test_validate_prints_details_on_source_failure`.
+        """
         from feather_etl.config import load_config
         from feather_etl.validate import run_validate
 
-        cfg = load_config(_make_sqlite_project(tmp_path, valid_path=False))
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        class FakeFailingSource:
+            type = "duckdb"
+            path = "/nope.duckdb"
+
+            def __init__(self) -> None:
+                self._last_error = "TLS Provider: certificate verify failed"
+
+            def check(self) -> bool:
+                return False
+
+        cfg.sources[0] = FakeFailingSource()
         report = run_validate(cfg)
 
-        assert report.sources[0].error is not None
-        assert report.sources[0].error != ""
+        assert report.sources[0].ok is False
+        assert report.sources[0].error == "TLS Provider: certificate verify failed"
 
     def test_label_uses_path_for_file_sources(self, tmp_path: Path):
         from feather_etl.config import load_config
@@ -927,27 +946,29 @@ from pathlib import Path
 import yaml
 
 from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
 
 
 def _make_project(tmp_path: Path, *, mode: str | None = None) -> Path:
-    """Build a minimal feather project. Returns config path."""
+    """Build a minimal feather project. Returns config path.
+
+    Note: ``load_config`` reads tables from ``discovery/curation.json``, not from
+    the YAML, so the project layout uses ``write_curation`` (the same pattern as
+    ``tests/commands/conftest.py::cli_env``).
+    """
     shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
     config: dict = {
-        "sources": [{"type": "sqlite", "path": "./source.sqlite"}],
+        "sources": [{"type": "sqlite", "name": "erp", "path": "./source.sqlite"}],
         "destination": {"path": "./feather_data.duckdb"},
-        "tables": [
-            {
-                "name": "orders",
-                "source_table": "orders",
-                "target_table": "bronze.orders",
-                "strategy": "full",
-            }
-        ],
     }
     if mode is not None:
         config["mode"] = mode
     config_path = tmp_path / "feather.yaml"
     config_path.write_text(yaml.dump(config))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "orders", "orders")],
+    )
     return config_path
 
 

--- a/docs/superpowers/specs/2026-04-19-test-restructure-design.md
+++ b/docs/superpowers/specs/2026-04-19-test-restructure-design.md
@@ -1,0 +1,531 @@
+# Test suite restructure: pytest-only, three-layer architecture
+
+Created: 2026-04-19
+Status: DRAFT
+Approved: Pending
+Issue: https://github.com/siraj-samsudeen/feather-etl/issues/40
+Type: Refactor
+
+## Summary
+
+Replace `scripts/hands_on_test.sh` (902 lines, 61 bash checks) with pytest-only
+coverage, and reorganize the existing 46-file flat `tests/` tree into a
+three-layer structure (`tests/e2e/`, `tests/integration/`, `tests/unit/`) so a
+reader can locate any test by what it exercises rather than by historical
+filename.
+
+The end state is a single PR that:
+
+- removes `scripts/hands_on_test.sh`,
+- moves every existing test into `tests/e2e/`, `tests/integration/`, or
+  `tests/unit/` per a written rule,
+- introduces a `ProjectFixture` + `cli` pair that becomes the standard harness
+  for end-to-end tests,
+- keeps the suite green at every commit so the branch is bisectable.
+
+## Background
+
+### What exists today
+
+- `scripts/hands_on_test.sh` — 902 lines, 61 bash `check()` calls grouped into
+  ~15 numbered stages (S1–S22, S-INCR). It shells out to `feather`, asserts
+  with `grep`/`run_ok`/`run_fail`, and uses inline YAML strings.
+- `tests/` — flat layout, 46 files, ~656 tests by file-level count
+  (CLAUDE.md says 653; small drift is normal). 42 of 46 files group tests
+  with `class TestFoo:` (no `unittest.TestCase` anywhere — only
+  `unittest.mock` is imported, which is pytest-compatible). 4 files use flat
+  function style.
+- `tests/commands/` — one subfolder, 11 files, all using `CliRunner` to
+  exercise individual CLI commands.
+- `tests/conftest.py` — five data fixtures (`client_db`, `config_path`,
+  `csv_data_dir`, `sqlite_db`, `sample_erp_db`) that copy `tests/fixtures/*`
+  into `tmp_path`.
+- `src/feather_etl/` — clean module tree (`commands/`, `sources/`,
+  `destinations/`, plus top-level modules for `config`, `state`, `pipeline`,
+  `transforms`, `cache`, `dq`, `schema_drift`, `alerts`, etc.). Easy to mirror.
+
+### What's broken about the current shape
+
+1. **Duplicate coverage with a maintenance tax.** Per issue #40, ~90% of the
+   bash checks are already covered by pytest tests. Updating CLI output
+   requires editing both bash greps and pytest assertions. The bash script's
+   stage count drifted (CLAUDE.md said 72 checks; actual is 61) and nobody
+   noticed because nobody reads bash test scripts line by line.
+2. **The flat `tests/` directory hides the level of every test.**
+   `test_integration.py` (811 lines) mixes regression bugs, error-isolation
+   integration tests, CLI validation, and full-pipeline e2e. `test_transforms.py`
+   (869 lines) mixes parser unit tests, transform-execution integration tests,
+   and CLI-level e2e. A reader cannot tell what layer they're in without
+   reading the test body.
+3. **Source tests are split across two axes.** `test_sources.py` (734 lines,
+   70 tests) holds the source protocol + file sources + registry; per-source
+   files (`test_postgres.py`, `test_mysql.py`, `test_sqlserver.py`,
+   `test_excel.py`, `test_json.py`, `test_csv_glob.py`) hold the rest.
+4. **Cross-cutting feature tests have no directory grouping.**
+   `test_incremental.py`, `test_schema_drift.py`, `test_dedup.py`,
+   `test_boundary_dedup.py`, `test_append.py`, `test_retry.py`,
+   `test_cache.py`, `test_alerts.py`, `test_dq.py`, `test_curation.py` all
+   sit flat next to unit tests for `test_config.py`, `test_state.py`.
+5. **No shared end-to-end harness.** Every e2e test re-derives the project
+   directory layout, hand-writes config and curation, and re-implements the
+   `duckdb.connect` boilerplate to query results. There is no Playwright-style
+   `page` equivalent — i.e., no single object that represents "a feather
+   project ready to run."
+
+## Design
+
+### Three-layer architecture
+
+```
+tests/
+  e2e/                          # CLI journeys; reads top-to-bottom = user story
+    conftest.py                 # ProjectFixture, project, cli fixtures
+    test_00_cli_structure.py
+    test_01_scaffold.py
+    test_02_validate.py
+    test_03_discover.py
+    test_04_extract_full.py
+    test_05_change_detection.py
+    test_06_incremental.py
+    test_07_transforms.py
+    test_08_dq.py
+    test_09_schema_drift.py
+    test_10_error_handling.py
+    test_11_path_resolution.py
+    test_12_cache.py
+    test_13_multi_source.py
+    test_14_status.py
+    test_15_history.py
+    test_16_view.py
+    test_17_json_output.py
+    test_18_sources_e2e.py      # SQLite/Postgres/etc. via CLI
+  integration/                  # Multi-module Python-API slices (no CLI)
+    test_pipeline.py
+    test_change_detection.py
+    test_incremental.py
+    test_schema_drift.py
+    test_transforms.py
+    test_dq.py
+    test_cache.py
+    test_dedup.py
+    test_append.py
+    test_retry.py
+    test_alerts.py
+    test_curation_pipeline.py
+    test_error_isolation.py
+    test_multi_source.py
+  unit/                         # Single-module; mirrors src/feather_etl/
+    test_config.py
+    test_state.py
+    test_curation.py
+    test_pipeline_helpers.py    # only if pipeline has unit-testable bits
+    test_transforms.py          # parse, discover, build_execution_order
+    test_cache.py               # unit-level cache helpers
+    test_dq.py                  # unit-level dq config parsing
+    test_schema_drift.py        # unit-level drift detection
+    test_alerts.py              # unit-level alert config + dispatch
+    test_discover_state.py
+    test_discover_io.py
+    test_output.py
+    test_viewer_server.py
+    sources/
+      test_registry.py
+      test_protocol.py
+      test_file_source.py
+      test_database_source.py
+      test_csv.py
+      test_excel.py
+      test_json.py
+      test_sqlite.py
+      test_duckdb_file.py
+      test_postgres.py
+      test_mysql.py
+      test_sqlserver.py
+      test_expand.py
+    destinations/
+      test_duckdb.py
+    commands/                   # ONLY if a command has internals worth
+                                # testing in isolation. Most commands' tests
+                                # live in tests/e2e/. Likely empty initially.
+  fixtures/                     # unchanged; data files
+  conftest.py                   # session-level (pg_ctl bootstrap); keep
+  helpers.py                    # shared module helpers; keep
+  README.md                     # documents the rule below
+```
+
+### The three-way decision rule
+
+For any test, ask in order:
+
+1. **Does it invoke the CLI?** (either `CliRunner.invoke(app, ...)` or
+   spawns the `feather` binary via subprocess) → `tests/e2e/`. File chosen
+   by workflow stage.
+2. **Does it exercise 2+ `src/feather_etl/` modules through a pipeline-level
+   API** (e.g., `pipeline.run_pipeline()`, `cache.run_cache()`)? →
+   `tests/integration/`. File chosen by feature/capability.
+3. **Otherwise — exercises a single module's functions/classes** →
+   `tests/unit/`. File mirrors the source path
+   (`src/feather_etl/sources/csv.py` → `tests/unit/sources/test_csv.py`).
+
+The rule has no carve-outs. `CliRunner` alone makes a test e2e even when it
+only tests one command; that is intentional, because the current
+`tests/commands/` files are already exercising the full CLI dispatch path.
+
+### Test style within files
+
+- **Flat function style by default.** `def test_foo(project, cli): ...` at
+  module level. Pytest's standard idiom.
+- **Class groupings allowed only when they add real grouping value:** several
+  tests share a `@pytest.fixture` defined inside the class, or a clear
+  sub-concept exists (e.g., `class TestCsvGlobChangeDetection:`). When in
+  doubt, prefer flat.
+- **No `unittest.TestCase`.** Use plain `assert`, `pytest.raises`,
+  `pytest.fixture`. `unittest.mock` is fine — that is the standard mock
+  library.
+
+### `ProjectFixture` and `cli` fixtures
+
+A `ProjectFixture` is a small object representing "a feather project on
+disk, ready to use." It bundles together the directory, the config path,
+the data DB path, the state DB path, and helpers for the things every e2e
+test does. The `cli` fixture is a callable that runs feather commands
+against that project.
+
+```python
+# tests/e2e/conftest.py
+class ProjectFixture:
+    def __init__(self, root: Path):
+        self.root = root
+
+    @property
+    def config_path(self) -> Path:
+        return self.root / "feather.yaml"
+
+    @property
+    def data_db_path(self) -> Path:
+        return self.root / "feather_data.duckdb"
+
+    @property
+    def state_db_path(self) -> Path:
+        return self.root / "feather_state.duckdb"
+
+    def write_config(self, **fields) -> None:
+        self.config_path.write_text(yaml.dump(fields, default_flow_style=False))
+
+    def write_curation(self, entries: list[tuple[str, str, str]]) -> None:
+        # entries: [(source_name, source_table, target_name), ...]
+        write_curation(self.root, [make_curation_entry(*e) for e in entries])
+
+    def copy_fixture(self, name: str) -> Path:
+        src = FIXTURES_DIR / name
+        dst = self.root / name
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        else:
+            shutil.copy2(src, dst)
+        return dst
+
+    def query(self, sql: str) -> list[tuple]:
+        with duckdb.connect(str(self.data_db_path), read_only=True) as con:
+            return con.execute(sql).fetchall()
+
+
+@pytest.fixture
+def project(tmp_path) -> ProjectFixture:
+    return ProjectFixture(tmp_path)
+
+
+@pytest.fixture
+def cli(project):
+    runner = CliRunner()
+    def run(*args: str):
+        return runner.invoke(app, list(args) + ["--config", str(project.config_path)])
+    return run
+```
+
+This is the **complete day-one API**. Methods are added only when a test
+that needs them is written; we do not pre-add `assert_table_rows`,
+`add_source`, or `run` shortcuts speculatively.
+
+The fixture lives in `tests/e2e/conftest.py` so existing tests under
+`tests/test_*.py` and `tests/commands/` are not affected by its presence
+during early waves.
+
+### What happens to existing fixtures
+
+`tests/conftest.py` keeps its session-level `pytest_configure` /
+`pytest_unconfigure` hooks (Postgres bootstrap) and the data-copy fixtures
+(`client_db`, `config_path`, `csv_data_dir`, `sqlite_db`, `sample_erp_db`).
+These continue to serve `tests/integration/` and `tests/unit/` tests.
+`tests/e2e/` tests use `ProjectFixture` and reach for raw fixture data via
+`project.copy_fixture(name)`.
+
+When integration/unit tests are migrated, they keep using the existing
+data fixtures unless adopting `ProjectFixture` is trivially better. We do
+not refactor working tests for purity.
+
+### The 5 gap tests
+
+Per issue #40 the bash script covers exactly five scenarios that pytest
+does not:
+
+| Gap | What | Lands in |
+|---|---|---|
+| 1 (S10) | `feather run --config /abs/path` from a different CWD | `tests/e2e/test_11_path_resolution.py` |
+| 2 (S13) | Missing `feather.yaml` produces "Config file not found" | `tests/e2e/test_02_validate.py` |
+| 3 (S14) | Error message appears on stdout only, not duplicated on stderr (BUG-1 regression) — uses `subprocess.run` because `CliRunner` merges streams. The exact subprocess invocation (`uv run feather …` vs direct binary path vs adding a `__main__.py`) is decided in the implementation plan; the test must drive the real `feather` entry point. | `tests/e2e/test_10_error_handling.py` |
+| 4 (S16a) | CSV `source.path` must be a directory, not a file | `tests/e2e/test_02_validate.py` |
+| 5 (S17) | SQLite source: `validate` + `setup` + `run` end-to-end | `tests/e2e/test_18_sources_e2e.py` |
+
+These are the canonical first tests that exercise `ProjectFixture`/`cli`.
+
+### Coverage-equivalence proof
+
+Before deletion, every numbered check in the bash script must be mapped to
+a pytest test. The mapping lives at
+`docs/superpowers/specs/2026-04-19-test-restructure-coverage-map.md` and
+is structured as:
+
+```
+| Bash check | What it asserts | Pytest test path |
+|---|---|---|
+| S1.1 | `feather init` creates feather.yaml | tests/e2e/test_01_scaffold.py::test_init_creates_feather_yaml |
+| S1.2 | ... | ... |
+| ... |
+```
+
+The map is updated as migration waves land. Wave E does not delete the
+bash script until every row has a non-empty `Pytest test path`.
+
+### Documentation to update
+
+- `CLAUDE.md`: the "Before you write a single line of code" block currently
+  references both `uv run pytest -q` and `bash scripts/hands_on_test.sh`.
+  The bash line is removed; the test count is corrected.
+- `docs/CONTRIBUTING.md`:
+  - "Rules for the fixing agent" item 4 (about updating
+    `scripts/hands_on_test.sh` BUG-labelled checks) is rewritten to point at
+    `tests/e2e/` (and at integration/unit if the bug lives there).
+  - "Rules for the fixing agent" item 5 (running both suites) is reduced to
+    a single pytest invocation.
+  - Re-review section's references to "New hands-on scenarios to add to
+    `scripts/hands_on_test.sh`" are rewritten to point at `tests/e2e/`.
+  - The subsection titled `### scripts/hands_on_test.sh` is replaced with
+    `### tests/e2e/` documenting the BUG-labelled regression test pattern
+    (write a failing test under e2e, mark it `BUG-N`, invert when fixed).
+- `tests/README.md` is created. Contents: the three-way decision rule, the
+  `ProjectFixture` API, the test-style guidance, and a table mapping each
+  workflow stage file (`test_00_…` … `test_18_…`) to the user-facing
+  command(s) it covers.
+
+## Delivery: waves on a single branch
+
+The work happens on one branch and lands as one PR. Internally it is broken
+into five waves; each wave's commits are atomic and bisectable, and each
+wave ends with `uv run pytest -q` green.
+
+### Wave A — Foundation
+
+1. Create directory skeletons: `tests/e2e/`, `tests/integration/`,
+   `tests/unit/`, `tests/unit/sources/`, `tests/unit/destinations/`,
+   `tests/unit/commands/`, each with `__init__.py`.
+2. Create `tests/e2e/conftest.py` with `ProjectFixture`, `project`, `cli`.
+3. Create `tests/e2e/test_fixture_smoke.py` exercising each public method
+   of `ProjectFixture` and `cli('--help')`.
+4. Port gap #1 → `tests/e2e/test_11_path_resolution.py`.
+5. Port gap #2 + gap #4 → `tests/e2e/test_02_validate.py`.
+6. Port gap #3 → `tests/e2e/test_10_error_handling.py` (uses
+   `subprocess.run`, not `CliRunner`).
+7. Port gap #5 → `tests/e2e/test_18_sources_e2e.py`.
+8. Create `tests/README.md` (decision rule + `ProjectFixture` API).
+9. Create the empty coverage-map file with the table header.
+
+End of Wave A: bash script still exists; existing 46 files are untouched;
+`uv run pytest -q` shows ~5 more tests than before Wave A (the gap tests).
+
+### Wave B — Migrate e2e
+
+For each existing file below, the migration task is: read the file,
+identify which tests are e2e (uses `CliRunner` or spawns `feather`), move
+them to the appropriate `tests/e2e/test_0X_*.py` file (creating it if
+needed), refactor to use `project`/`cli`, run `uv run pytest -q`, commit.
+
+Files migrated (or split) in Wave B:
+
+- `tests/commands/test_init.py` → `tests/e2e/test_01_scaffold.py`
+- `tests/commands/test_validate.py` → `tests/e2e/test_02_validate.py`
+- `tests/commands/test_discover.py` + `tests/commands/test_discover_multi_source.py` → `tests/e2e/test_03_discover.py`
+- `tests/commands/test_setup.py` + `tests/commands/test_run.py` → `tests/e2e/test_04_extract_full.py`
+- `tests/commands/test_status.py` → `tests/e2e/test_14_status.py`
+- `tests/commands/test_history.py` → `tests/e2e/test_15_history.py`
+- `tests/commands/test_view.py` → `tests/e2e/test_16_view.py`
+- `tests/commands/test_cache.py` → `tests/e2e/test_12_cache.py`
+- `tests/commands/test_multi_source_guard.py` → `tests/e2e/test_13_multi_source.py`
+- `tests/test_e2e.py` → `tests/e2e/test_04_extract_full.py` (merge)
+- `tests/test_multi_source_e2e.py` → `tests/e2e/test_13_multi_source.py` (merge)
+- `tests/test_json_output.py` → `tests/e2e/test_17_json_output.py`
+- `tests/test_cli_structure.py` → `tests/e2e/test_00_cli_structure.py`
+- `tests/test_explicit_name_flag.py` → `tests/e2e/test_03_discover.py` (merge)
+- `tests/test_integration.py` (e2e portions only — `TestSampleErpFullPipeline`, `TestCsvFullPipeline`, `TestSqliteFullPipeline`, `TestValidationGuards`) → split into `tests/e2e/test_04_extract_full.py` + `tests/e2e/test_02_validate.py` + `tests/e2e/test_18_sources_e2e.py`
+- `tests/test_transforms.py` (e2e portions — `TestE2ETransformPipeline`, `TestCLISetupTransforms`) → `tests/e2e/test_07_transforms.py`
+
+End of Wave B: `tests/commands/` directory removed; the listed flat files
+either deleted (if fully migrated) or reduced to their non-e2e portions.
+`uv run pytest -q` green.
+
+### Wave C — Migrate integration
+
+For each existing file, identify integration-level tests (multi-module
+Python-API, not CLI), move into `tests/integration/test_<feature>.py`,
+delete from origin file when fully drained.
+
+Files migrated (or split) in Wave C:
+
+- `tests/test_incremental.py` → `tests/integration/test_incremental.py`
+- `tests/test_schema_drift.py` → `tests/integration/test_schema_drift.py`
+- `tests/test_dedup.py` → `tests/integration/test_dedup.py`
+- `tests/test_boundary_dedup.py` → `tests/integration/test_change_detection.py` (or its own file if size warrants)
+- `tests/test_append.py` → `tests/integration/test_append.py`
+- `tests/test_retry.py` → split: integration parts → `tests/integration/test_retry.py`; unit parts deferred to Wave D
+- `tests/test_curation_config_integration.py` → `tests/integration/test_curation_pipeline.py`
+- `tests/test_pipeline.py` → `tests/integration/test_pipeline.py`
+- `tests/test_csv_glob.py` → split: integration (full glob pipeline) → `tests/integration/test_change_detection.py`; unit (CSV parsing) deferred to Wave D
+- `tests/test_transforms.py` (integration portions — `TestExecuteTransforms`, `TestRebuildMaterializedGold`, `TestPipelineTransformRebuild`) → `tests/integration/test_transforms.py`
+- `tests/test_integration.py` (integration portions — `TestErrorIsolation`, `TestPipelineReturnsOnFailure`, `TestKnownBugs` if integration-level) → `tests/integration/test_error_isolation.py` + appropriate file
+- `tests/test_dq.py` (integration portions) → `tests/integration/test_dq.py`
+- `tests/test_cache.py` (integration portions) → `tests/integration/test_cache.py`
+- `tests/test_alerts.py` (integration portions if any) → `tests/integration/test_alerts.py`
+
+End of Wave C: cross-cutting feature files moved or substantially drained.
+`uv run pytest -q` green.
+
+### Wave D — Migrate unit
+
+Move what's left into `tests/unit/`, mirroring `src/feather_etl/`.
+
+Files migrated (or split) in Wave D:
+
+- `tests/test_config.py` → `tests/unit/test_config.py`
+- `tests/test_state.py` → `tests/unit/test_state.py`
+- `tests/test_curation.py` → `tests/unit/test_curation.py`
+- `tests/test_destinations.py` → `tests/unit/destinations/test_duckdb.py`
+- `tests/test_discover_state.py` → `tests/unit/test_discover_state.py`
+- `tests/test_discover_io.py` → `tests/unit/test_discover_io.py`
+- `tests/test_discover_expansion.py` + `tests/test_expand_db_sources.py` → `tests/unit/sources/test_expand.py` (consolidate)
+- `tests/test_sources.py` → split into `tests/unit/sources/test_registry.py`, `tests/unit/sources/test_protocol.py`, `tests/unit/sources/test_file_source.py`, `tests/unit/sources/test_database_source.py`
+- `tests/test_postgres.py` → `tests/unit/sources/test_postgres.py`
+- `tests/test_mysql.py` → `tests/unit/sources/test_mysql.py`
+- `tests/test_sqlserver.py` → `tests/unit/sources/test_sqlserver.py`
+- `tests/test_excel.py` → `tests/unit/sources/test_excel.py`
+- `tests/test_json.py` → `tests/unit/sources/test_json.py`
+- `tests/test_csv_glob.py` (unit remainder) → `tests/unit/sources/test_csv.py`
+- `tests/test_mode.py` → `tests/unit/test_mode.py` (or split if it touches multiple modules)
+- `tests/test_viewer_server.py` → `tests/unit/test_viewer_server.py`
+- `tests/test_retry.py` (unit remainder) → `tests/unit/test_retry.py` (or merge into `tests/unit/test_state.py` if all about StateManager)
+- `tests/test_transforms.py` (unit remainder — `TestParseTransformFile`, `TestDiscoverTransforms`, `TestBuildExecutionOrder`) → `tests/unit/test_transforms.py`
+- `tests/test_dq.py`, `tests/test_cache.py`, `tests/test_alerts.py` (unit remainders) → `tests/unit/test_dq.py`, `tests/unit/test_cache.py`, `tests/unit/test_alerts.py`
+
+End of Wave D: zero flat `test_*.py` files under `tests/`. Tree contains
+only `tests/e2e/`, `tests/integration/`, `tests/unit/`, `tests/fixtures/`,
+`tests/conftest.py`, `tests/helpers.py`, `tests/README.md`.
+
+### Wave E — Coverage proof, deletion, doc updates
+
+1. Complete the coverage-map document — every numbered bash check has a
+   non-empty pytest test path. Run `bash scripts/hands_on_test.sh` one last
+   time, confirm 61/61 PASS, run `uv run pytest -q`, confirm green.
+2. Delete `scripts/hands_on_test.sh`.
+3. Update `CLAUDE.md` (remove bash line; correct test count).
+4. Update `docs/CONTRIBUTING.md` (rewrite items 4 + 5 of "Rules for the
+   fixing agent"; replace `### scripts/hands_on_test.sh` subsection with
+   `### tests/e2e/`; remove all other `hands_on_test` references).
+5. Final `uv run pytest -q` green; final grep for `hands_on_test` returns
+   nothing in active docs (only specs/plans/reviews).
+
+## Per-task discipline
+
+Every task that moves or splits a test file follows this protocol:
+
+1. Read the source file. Categorize each test (e2e / integration / unit)
+   per the rule.
+2. For each test:
+   - if e2e and the destination file does not yet exist, create it with a
+     module docstring explaining the workflow stage;
+   - if e2e, refactor to use `project`/`cli`;
+   - if integration or unit, leave the test largely as-is (only fix imports
+     and adopt `ProjectFixture` if trivially better).
+3. Use `git mv` when moving a whole file unchanged so blame is preserved.
+   For split moves, copy + delete in separate commits is acceptable.
+4. Add a one-line comment at the top of the new file: `# Migrated from
+   tests/<old_path>.py` (per migration; can be removed after Wave E).
+5. Run `uv run pytest -q`. Must be green.
+6. Commit with format: `test(<wave-letter>): migrate <old_path> -> <new_path>`.
+
+## Risks and mitigations
+
+- **`ProjectFixture` API turns out wrong-shape mid-migration.** This is the
+  reason migration is in the same logical unit as foundation. If a Wave B/C
+  file needs a method we don't have, we add it to `ProjectFixture` (atomic
+  commit), refactor only the affected tests, continue. No "Phase 2 found
+  problems with Phase 1" gap.
+- **Splitting large mixed files (`test_integration.py`,
+  `test_transforms.py`) introduces subtle behavior changes.** Mitigation:
+  per-task discipline keeps each split atomic; class-level fixtures are
+  preserved when classes survive; `uv run pytest -q` green is the gate
+  before commit.
+- **Test count drifts from claims in `CLAUDE.md`.** Mitigation: Wave E
+  recomputes and rewrites the count; do not hardcode counts elsewhere.
+- **Bash script deletion before coverage map is honest.** Mitigation: Wave E
+  ordering — coverage map must be 100% complete with non-empty pytest paths
+  before `rm scripts/hands_on_test.sh` commit.
+- **Long-running branch accumulates merge conflicts.** Mitigation: rebase
+  on main after each wave. Test files rarely conflict with `src/` work, so
+  conflicts should be limited.
+
+## Done signal
+
+A reviewer or future agent can confirm "this is done" by running these
+commands and seeing the matching outputs:
+
+```bash
+# 1. All tests pass (existing count + 5 new gap tests, minus any consolidated
+#    duplicates revealed during migration). Run before deletion of bash script
+#    AND after, both green.
+uv run pytest -q
+
+# 2. The bash script is gone
+test ! -f scripts/hands_on_test.sh && echo OK
+
+# 3. No flat test files remain at tests/ root (only conftest.py, helpers.py,
+#    README.md, and the e2e/integration/unit/fixtures directories)
+ls tests/test_*.py 2>/dev/null | wc -l   # expected: 0
+
+# 4. tests/commands/ is gone
+test ! -d tests/commands && echo OK
+
+# 5. The new layout exists and is non-empty
+test -d tests/e2e && test -d tests/integration && test -d tests/unit && echo OK
+ls tests/e2e/test_*.py tests/integration/test_*.py tests/unit/test_*.py | wc -l
+# expected: many
+
+# 6. No active doc references the deleted script
+grep -rn "hands_on_test" CLAUDE.md docs/CONTRIBUTING.md README.md \
+  | grep -v "docs/superpowers/specs/" \
+  | grep -v "docs/plans/" \
+  | grep -v "docs/reviews/"
+# expected: no output
+
+# 7. The coverage map is complete
+grep -c "^| S" docs/superpowers/specs/2026-04-19-test-restructure-coverage-map.md
+# expected: 61 (one row per bash check)
+grep -E "^\| S[^|]+\|[^|]+\|\s*\|" docs/superpowers/specs/2026-04-19-test-restructure-coverage-map.md
+# expected: no output (no row with empty pytest path)
+```
+
+If all seven pass, the migration is complete and the issue can be closed.
+
+## Open questions
+
+None. All design choices are committed (Strategy B three-layer; flat
+function style by default; minimal `ProjectFixture`; one PR; coverage-map
+gate before deletion).

--- a/docs/superpowers/specs/2026-04-19-thin-cli-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-19-thin-cli-refactor-design.md
@@ -1,0 +1,297 @@
+# Thin-CLI Refactor Design (`#43`)
+
+- **Issue:** [#43](https://github.com/siraj-samsudeen/feather-etl/issues/43)
+- **Date:** 2026-04-19
+- **Status:** Design approved, ready for implementation planning
+- **Type:** Refactor (behavior-preserving)
+- **Scope:** Refactor `commands/<name>.py` modules to follow the thin-CLI ↔ pure-core pattern already used by `commands/run.py` ↔ `pipeline.py` and `commands/cache.py` ↔ `cache.py`.
+
+## Goal
+
+Split each command module into two layers so the orchestration logic is reusable and directly testable without going through `CliRunner`:
+
+| Layer | Responsibility | Typer-aware? |
+|---|---|---|
+| `commands/<name>.py` | Flag parsing, prompts, output formatting, exit-code translation. | Yes |
+| `<name>.py` (top-level) | Pure orchestration / IO / data flow. Returns values or raises domain exceptions. | **No** |
+
+## Non-Negotiable Constraints
+
+1. **No CLI behavior changes.** Every `feather <cmd> --flag` invocation produces byte-identical stdout/stderr, identical exit codes, identical prompts, identical JSON output.
+2. **No flag/option/default changes.** The CLI surface is frozen.
+3. **No edits outside the named scope.** `pipeline.py`, `cache.py`, `state.py`, `config.py`, `init_wizard.py`, `viewer_server.py`, `commands/_common.py`, `commands/run.py`, and `commands/cache.py` are not touched. The only exception is if Task 3's purity test surfaces an unexpected `typer` import in `viewer_server.py` or `init_wizard.py`, in which case that import is removed in the same commit.
+4. **No new features during refactor.** Scope discipline matters; this is a structural change only.
+5. **One commit per command refactor.** Per the issue's explicit requirement.
+6. **Top-level core modules must not import `typer`.** Enforced by an automated purity test (see Task 3).
+7. **Existing test suites stay green.** `uv run pytest -q` (653 tests) and `bash scripts/hands_on_test.sh` (61 checks) are the safety net.
+
+## Reference Pattern
+
+Two modules already follow the target shape and serve as references:
+
+- `commands/run.py` (74 lines, thin Typer wrapper) ↔ `pipeline.py` (`run_all() -> list[ExtractResult]`)
+- `commands/cache.py` (154 lines, thin Typer wrapper with rich grouped output) ↔ `cache.py` (`run_cache() -> list[CacheResult]`)
+
+Both demonstrate the convention this refactor generalizes:
+
+- Per-item failures across many items (one source failed, one table failed) are captured as `status="failure"` entries in the result list. Cores do not raise for per-item failures.
+- The CLI sums failures and decides exit codes.
+- The CLI is purely a formatter for the data the core returns.
+
+## Convention for the New Cores
+
+To keep the refactor from drifting, every new core in this work follows these rules:
+
+| Concern | How the core handles it |
+|---|---|
+| Per-item failure across many items | Capture as `status="failure"` entry in the result list. Don't raise. CLI sums and decides exit code. (Matches `pipeline`, `cache`.) |
+| Fatal preconditions (config not found, validation errors, state DB missing, prod-mode guard tripped) | Raise a domain exception. CLI catches and translates to `typer.echo(err) + typer.Exit(code)`. |
+| Pure read-through (history, status) | Return `list[dict]` straight from `StateManager`. The "no state DB" precondition raises `StateDBMissingError`. |
+| Multi-stage orchestration with structured output (discover, setup, validate) | Return a small dataclass that carries the counts/items the CLI needs to format. |
+| User interaction (prompts, `typer.confirm`) | Stays in the CLI wrapper. The core takes a pre-resolved decision as a value, never a callback. |
+
+Domain exceptions live in `src/feather_etl/exceptions.py` if more than one core needs them. If only one core needs an exception, define it inline in that core. Decided in Task 1 when `StateDBMissingError` is introduced; Task 2 reuses it (so it lives in `exceptions.py`).
+
+## Architecture
+
+### Target file layout (additions only — no removals)
+
+```text
+src/feather_etl/
+  exceptions.py            # NEW: shared domain exceptions (StateDBMissingError, ...)
+  discover.py              # NEW: detect_renames_for_sources, apply_rename_decision, run_discover
+  setup.py                 # NEW: run_setup, SetupResult
+  validate.py              # NEW: run_validate, ValidateReport, SourceCheckResult
+  status.py                # NEW: load_status
+  history.py               # NEW: load_history
+  commands/
+    discover.py            # SHRUNK from 274 → ~80 lines
+    setup.py               # SHRUNK from 105 → ~50 lines
+    validate.py            # SHRUNK from 66 → ~40 lines
+    status.py              # SHRUNK from 68 → ~40 lines
+    history.py             # SHRUNK from 75 → ~40 lines
+    init.py                # VERIFIED only (likely no change)
+    view.py                # VERIFIED only (already conformant)
+
+tests/
+  test_core_module_purity.py   # NEW: parametrized "no typer import" assertion
+  test_history_core.py         # NEW: direct unit tests, no CliRunner
+  test_status_core.py          # NEW
+  test_validate_core.py        # NEW
+  test_setup_core.py           # NEW
+  test_discover_core.py        # NEW
+```
+
+### Untouched (do not edit)
+
+`cli.py`, `commands/_common.py`, `commands/cache.py`, `commands/run.py`, `pipeline.py`, `cache.py`, `state.py`, `config.py`, `init_wizard.py`, `viewer_server.py`, all `sources/*`, `destinations/*`, `transforms.py`, `dq.py`, `alerts.py`, `schema_drift.py`, `output.py`, `curation.py`. Plus all existing tests except for any that incidentally need import-path updates (none expected — all existing tests go through `CliRunner` or import from `pipeline`/`cache`).
+
+### Concrete API shapes for the new cores
+
+```python
+# src/feather_etl/exceptions.py
+class StateDBMissingError(Exception):
+    """Raised when an operation requires the state DB but it does not exist."""
+
+# src/feather_etl/history.py
+def load_history(state_path: Path, *, table: str | None = None,
+                 limit: int = 20) -> list[dict]:
+    """Return recent run history rows. Raises StateDBMissingError if no DB."""
+
+# src/feather_etl/status.py
+def load_status(state_path: Path) -> list[dict]:
+    """Return per-table last-run status rows. Raises StateDBMissingError if no DB."""
+
+# src/feather_etl/validate.py
+@dataclass
+class SourceCheckResult:
+    type: str
+    label: str           # path or host, whichever the source exposes
+    ok: bool
+    error: str | None    # source._last_error when ok is False
+
+@dataclass
+class ValidateReport:
+    sources: list[SourceCheckResult]
+    tables_count: int
+    all_ok: bool         # True iff every source.ok is True
+
+def run_validate(cfg: FeatherConfig) -> ValidateReport: ...
+
+# src/feather_etl/setup.py
+@dataclass
+class SetupResult:
+    state_db_path: Path
+    destination_path: Path
+    transform_results: list[TransformResult] | None  # None if no transforms found
+
+def run_setup(cfg: FeatherConfig) -> SetupResult: ...
+
+# src/feather_etl/discover.py
+@dataclass
+class RenameDetection:
+    proposals: list[tuple[str, str]]   # (old_name, new_name)
+    ambiguous: list[tuple[str, list[str]]]  # (new_name, [candidate_old_names])
+
+@dataclass
+class SourceDiscoveryResult:
+    name: str
+    decision: str        # "new" | "retry" | "rerun" | "cached" | "skip" | "removed"
+    status: str          # "succeeded" | "failed" | "cached" | "skipped" | "pruned"
+    table_count: int = 0
+    output_path: Path | None = None
+    error: str | None = None
+
+@dataclass
+class DiscoverReport:
+    results: list[SourceDiscoveryResult]
+    succeeded_count: int
+    failed_count: int
+    cached_count: int
+    pruned_count: int
+    state_last_run_at: str | None  # for the "state file found, last run X" header
+
+def detect_renames_for_sources(state, sources) -> RenameDetection: ...
+
+def apply_rename_decision(state, accepted: list[tuple[str, str]],
+                          rejected: list[tuple[str, str]],
+                          sources, config_dir: Path) -> None: ...
+
+def run_discover(cfg: FeatherConfig, config_dir: Path, *,
+                 refresh: bool, retry_failed: bool, prune: bool) -> DiscoverReport: ...
+```
+
+The CLI wrappers handle prompt UX and translate `DiscoverReport`/`SetupResult`/`ValidateReport` into the existing per-line output and exit codes.
+
+## Task Breakdown
+
+Each task = one commit. TDD: the direct unit test for the new core is written first and demonstrates the core works without `CliRunner`; only then is the CLI wrapper rewritten to delegate.
+
+### Task 1 — Extract `history` core
+
+- **What:** Create `src/feather_etl/exceptions.py` with `StateDBMissingError`. Create `src/feather_etl/history.py` with `load_history()`. Rewrite `commands/history.py` to delegate.
+- **TDD test:** `tests/test_history_core.py::test_load_history_returns_rows_from_state_db`, `test_raises_state_db_missing_when_no_db`. Both use a real DuckDB fixture, no Typer.
+- **Code:** `load_history` is ~10 lines: existence check → `StateManager(path).get_history(table_name=..., limit=...)`. Wrapper catches `StateDBMissingError` and translates to the existing `"No state DB found. Run 'feather run' first."` message + `Exit(1)`.
+
+### Task 2 — Extract `status` core
+
+- **What:** Create `src/feather_etl/status.py` with `load_status()` reusing `StateDBMissingError`. Rewrite `commands/status.py`.
+- **TDD test:** `tests/test_status_core.py::test_load_status_returns_rows`, `test_raises_state_db_missing_when_no_db`.
+- **Code:** ~8 lines for the core. Wrapper preserves the existing `"No state DB found. Run 'feather setup' first."` message + `Exit(1)`.
+
+### Task 3 — Add core-module purity test
+
+- **What:** Create `tests/test_core_module_purity.py` with a parametrized test that asserts each pure-core module has no `typer` import in its source. Initially populate with the modules that already exist as pure cores: `pipeline`, `cache`, `viewer_server`, `init_wizard`, plus the two added in Tasks 1–2: `history`, `status`, `exceptions`.
+- **Why this exists:** The issue specifies the no-`typer`-import constraint as a manual `grep` check. Encoding it as a test makes it self-enforcing and regression-proof. Subsequent tasks add their new module to the parametrize list as part of the same commit.
+- **TDD test:** The test itself is the new test. Implementation:
+  ```python
+  import importlib, inspect
+  import pytest
+  CORE_MODULES = ["feather_etl.pipeline", "feather_etl.cache",
+                  "feather_etl.viewer_server", "feather_etl.init_wizard",
+                  "feather_etl.history", "feather_etl.status",
+                  "feather_etl.exceptions"]
+  @pytest.mark.parametrize("module_name", CORE_MODULES)
+  def test_core_module_does_not_import_typer(module_name):
+      module = importlib.import_module(module_name)
+      source = inspect.getsource(module)
+      assert "import typer" not in source, f"{module_name} imports typer"
+      assert "from typer" not in source, f"{module_name} imports from typer"
+  ```
+- **Risk:** If `viewer_server` or `init_wizard` fails the test, fix the offending import in the same commit.
+
+### Task 4 — Verify `init` is already conformant
+
+- **What:** Review `commands/init.py`. Confirm the dir-exists guard belongs in the CLI (it's a UX/overwrite-prevention concern, not a scaffolding correctness rule — `init_wizard.scaffold_project()` should remain callable from any context without surprise prompts). Confirm `init_wizard` passes the purity test from Task 3.
+- **Outcome:** If no tidy-up surfaces, **skip the commit and note in PR description "Task 4: verified, no changes needed."** Empty commits are noise; the spec + PR description are the audit trail. If a tidy-up surfaces, commit it.
+
+### Task 5 — Extract `validate` core
+
+- **What:** Create `src/feather_etl/validate.py` with `ValidateReport`, `SourceCheckResult`, and `run_validate()`. Rewrite `commands/validate.py` to call it and format output. Add `feather_etl.validate` to the purity test parametrize list.
+- **TDD test:** `tests/test_validate_core.py::test_run_validate_reports_each_source_status`, `test_returns_all_ok_false_when_any_source_check_fails`, `test_propagates_last_error_for_failed_sources`.
+- **Code:** Iterate `cfg.sources`, call `source.check()`, build `SourceCheckResult(type, label, ok, error)` for each. Set `all_ok = all(r.ok for r in results)`. ~30 lines including the dataclasses. The config-load + validation-write step (`commands/_common._load_and_validate()`) stays as-is — it's a CLI concern that writes the user-visible JSON and raises `typer.Exit`.
+
+### Task 6 — Extract `setup` core
+
+- **What:** Create `src/feather_etl/setup.py` with `SetupResult` and `run_setup()`. Move state init, schema setup, and transform execution out of `commands/setup.py`. Add `feather_etl.setup` to the purity test parametrize list.
+- **TDD test:** `tests/test_setup_core.py::test_run_setup_initializes_state_and_destination`, `test_run_setup_executes_transforms_when_present`, `test_run_setup_in_prod_mode_runs_gold_only`, `test_run_setup_returns_none_transforms_when_no_transforms_found`.
+- **Code:** ~50 lines. The conditional transform discovery + mode-aware execution (prod-mode runs gold-only; non-prod uses `force_views=True`) must be preserved exactly. Wrapper formats the existing summary lines (silver/gold/views/tables counts) from `SetupResult.transform_results`.
+
+### Task 7 — Extract `discover` core (the big one)
+
+- **What:** Create `src/feather_etl/discover.py` with three top-level functions:
+  - `detect_renames_for_sources(state, sources) -> RenameDetection` (pure detection, no I/O)
+  - `apply_rename_decision(state, accepted, rejected, sources, config_dir) -> None` (applies a pre-resolved decision)
+  - `run_discover(cfg, config_dir, *, refresh, retry_failed, prune) -> DiscoverReport` (per-source discovery loop; assumes renames already resolved)
+
+  Move `_fingerprint_for()` and `_write_schema()` helpers into the new module. The CLI wrapper handles the `typer.confirm` interactively, translates `--yes`/`--no-renames`/TTY-state into the call to `apply_rename_decision`, and calls `serve_and_open()` after `run_discover()` returns. Add `feather_etl.discover` to the purity test parametrize list.
+
+- **Why this shape:** Splitting rename handling out of `run_discover` makes each function pure and value-driven. The rename phase and the per-source discovery loop are logically independent — they were always two phases stapled together. A callback parameter (`confirm_renames: Callable | None`) was rejected because callbacks let the core do arbitrary I/O via the callback, defeating purity, and they're harder to test than pre-resolved values.
+
+- **TDD tests** (`tests/test_discover_core.py`):
+  - `test_detect_renames_for_sources_finds_proposals_when_fingerprints_match`
+  - `test_detect_renames_for_sources_returns_ambiguous_when_multiple_candidates`
+  - `test_apply_rename_decision_renames_state_and_files_for_accepted`
+  - `test_apply_rename_decision_marks_orphaned_for_rejected`
+  - `test_run_discover_records_succeeded_sources_with_table_counts`
+  - `test_run_discover_records_failed_sources_with_error_message`
+  - `test_run_discover_with_prune_removes_state_and_files`
+  - `test_run_discover_with_refresh_ignores_cached_state`
+  - `test_run_discover_with_retry_failed_only_retries_failed`
+  - `test_run_discover_handles_pre_set_last_error_from_expand_db_sources`
+
+- **Code:** ~150 lines for the core (vs. 274 mixed). Wrapper ~80 lines: flag parsing → rename decision computation (the `--yes` / `--no-renames` / TTY logic) → `run_discover()` call → output formatting → `serve_and_open()` → exit code (2 if any failures).
+
+## Dependency Chain
+
+Strict linear order, one commit per task:
+
+```
+Task 1 (history) → Task 2 (status) → Task 3 (purity test) → Task 4 (init verify)
+                                                                  ↓
+                                       Task 5 (validate) → Task 6 (setup) → Task 7 (discover)
+```
+
+**Ordering rationale:**
+
+- **Task 1 → 2:** `status` reuses `StateDBMissingError` defined by `history`. Doing `history` first means it decides where the exception lives (`exceptions.py`).
+- **Task 2 → 3:** Purity test arrives after the two simplest cores so it has more entries from day one and any drift in the convention has already surfaced.
+- **Task 3 → 4:** Purity test must exist before `init` verification because the verification *is* "does `init_wizard` pass the purity test."
+- **Task 4 → 5:** `validate` is the first dataclass-shaped core. Doing it before `setup` lets the `ValidateReport` / `SourceCheckResult` shape stabilize before `setup` / `discover` adopt the same convention.
+- **Task 5 → 6 → 7:** Increasing complexity. `setup` introduces side-effecting dataclasses; `discover` is the boss fight. Each prior task de-risks the next.
+
+No parallelism. Every task touches a different file in `src/feather_etl/` and a different test file, but they share the convention contract that's still solidifying. Sequential execution lets each task refine the convention for the next.
+
+## Done Signal
+
+The single command sequence that proves it all works end-to-end:
+
+```bash
+uv run pytest -q && bash scripts/hands_on_test.sh && \
+  for f in discover setup validate status history; do
+    grep -L typer "src/feather_etl/$f.py" >/dev/null && echo "$f: pure ✓" || echo "$f: HAS TYPER ✗"
+  done && \
+  uv run pytest -q tests/test_core_module_purity.py tests/test_*_core.py -v
+```
+
+When this runs clean — pytest green (653+ tests, including the new direct-unit-test files), 61 hands-on checks green, all five new core modules grep-clean of `typer`, and the new direct-unit-test files for each core module pass without any `CliRunner` import — the refactor is done.
+
+**Bonus invariant for code review:** `git log --oneline <branch> ^main` shows exactly 6 or 7 commits (one per task, possibly skipping Task 4), each scoped to one command.
+
+## Out of Scope
+
+- Adding features or new CLI flags while refactoring.
+- Changing the CLI surface — every command's `--flag` list stays identical.
+- Touching `pipeline.py`, `cache.py`, `_common.py`, or other core modules beyond the extractions described.
+- Refactoring `cache.py` or `commands/cache.py` (already conformant).
+- Issue #40 (retiring `scripts/hands_on_test.sh` in favor of pytest E2E) — independent.
+- Issue #15 follow-ups — independent.
+- Performance optimizations.
+- Adding type annotations beyond what the cores need to declare their public API.
+
+## Open Questions
+
+None at design time. The two design-level open questions raised during brainstorming were resolved:
+
+1. **Rename handling in `discover` extraction:** Split into three pure top-level functions (`detect_renames_for_sources`, `apply_rename_decision`, `run_discover`) rather than a callback parameter. The CLI wrapper holds prompt UX in one place.
+2. **`view`/`init` verify-only tasks:** Encoded as an automated purity test (Task 3) that turns the issue's manual `grep` check into a self-enforcing assertion. Empty commits are avoided; verification audit trail lives in spec + PR description.

--- a/src/feather_etl/commands/discover.py
+++ b/src/feather_etl/commands/discover.py
@@ -85,9 +85,14 @@ def discover(
     cfg = _load_and_validate(config, discover_mode=True)
     target_dir = Path(".")
 
+    # Capture the prior `last_run_at` for the header BEFORE any state mutation.
+    # The rename phase below may call `state.save()`, which updates the
+    # timestamp; we want the truly-prior discover run, not the rename save.
+    state = DiscoverState.load(target_dir)
+    prior_last_run_at = state.last_run_at
+
     # Rename phase (only when not in refresh/prune mode — preserves prior behavior).
     if not (refresh or prune):
-        state = DiscoverState.load(target_dir)
         sources = expand_db_sources(cfg.sources)
         detection = detect_renames_for_sources(state, sources)
 
@@ -113,16 +118,6 @@ def discover(
             )
             state.save()
 
-    # Header line — match prior CLI exactly.
-    state = DiscoverState.load(target_dir)
-    if state.last_run_at:
-        typer.echo(
-            f"Discovering from {config.name} (state file found, "
-            f"last run {state.last_run_at})..."
-        )
-    else:
-        typer.echo(f"Discovering from {config.name}...")
-
     report = run_discover(
         cfg,
         target_dir,
@@ -131,13 +126,24 @@ def discover(
         prune=prune,
     )
 
-    # Per-source line output (match prior format).
+    # Prune mode short-circuits BEFORE the "Discovering from" header — matches
+    # prior CLI behavior (the pre-refactor wrapper returned from the prune
+    # branch before reaching the header block).
     if prune:
         for r in report.results:
             if r.status == "pruned" and r.output_path is not None:
                 typer.echo(f"  Pruned: {r.output_path.name}")
         typer.echo(f"\nPruned {report.pruned_count} removed/orphaned entries.")
         return
+
+    # Header line — uses the pre-rename-mutation timestamp captured above.
+    if prior_last_run_at:
+        typer.echo(
+            f"Discovering from {config.name} (state file found, "
+            f"last run {prior_last_run_at})..."
+        )
+    else:
+        typer.echo(f"Discovering from {config.name}...")
 
     total = len(report.results)
     for idx, r in enumerate(report.results, start=1):

--- a/src/feather_etl/commands/discover.py
+++ b/src/feather_etl/commands/discover.py
@@ -1,50 +1,62 @@
-"""`feather discover` command — iterates every source in feather.yaml."""
+"""`feather discover` command — thin Typer wrapper over feather_etl.discover."""
 
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
 import typer
 
 from feather_etl.commands._common import _load_and_validate
-from feather_etl.config import schema_output_path
-from feather_etl.discover_state import (
-    DiscoverState,
-    apply_renames,
-    classify,
-    detect_renames,
+from feather_etl.discover import (
+    apply_rename_decision,
+    detect_renames_for_sources,
+    run_discover,
 )
+from feather_etl.discover_state import DiscoverState
 from feather_etl.sources.expand import expand_db_sources
 from feather_etl.viewer_server import serve_and_open
 
 
-def _write_schema(source, target_dir: Path) -> tuple[Path, int]:
-    """Discover `source` and write JSON. Returns (path, table_count)."""
-    schemas = source.discover()
-    payload = [
-        {
-            "table_name": s.name,
-            "columns": [{"name": c[0], "type": c[1]} for c in s.columns],
-        }
-        for s in schemas
-    ]
-    out = target_dir / schema_output_path(source)
-    out.write_text(json.dumps(payload, indent=2))
-    return out, len(schemas)
+def _resolve_rename_decision(
+    proposals: list[tuple[str, str]],
+    *,
+    yes: bool,
+    no_renames: bool,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """Echo proposals and resolve --yes / --no-renames / TTY confirm.
 
-
-def _fingerprint_for(source) -> str:
-    """Composition per spec §6.7.
-
-    DB sources: '<type>:<host>:<port>:<database>'. File sources: '<type>:<absolute_path>'.
+    Returns ``(accepted, rejected)``. May raise ``typer.Exit(3)`` if the
+    decision is required but stdin is not a TTY.
     """
-    if hasattr(source, "host") and source.host is not None:
-        return (
-            f"{source.type}:{source.host}:{source.port or ''}:{source.database or ''}"
+    proposal_err = not sys.stdin.isatty()
+    for old_name, new_name in proposals:
+        typer.echo(
+            f"  Rename inferred: {old_name} -> {new_name}",
+            err=proposal_err,
         )
-    return f"{source.type}:{Path(source.path).resolve()}"
+
+    if no_renames:
+        for old_name, new_name in proposals:
+            typer.echo(f"  Kept {old_name} orphaned; treating {new_name} as new")
+        return [], list(proposals)
+
+    if yes:
+        return list(proposals), []
+
+    if sys.stdin.isatty():
+        if typer.confirm("Accept all?", default=True):
+            return list(proposals), []
+        for old_name, new_name in proposals:
+            typer.echo(f"  Kept {old_name} orphaned; treating {new_name} as new")
+        return [], list(proposals)
+
+    typer.echo(
+        "Rename confirmation required in non-interactive mode. "
+        "Re-run with --yes to accept or --no-renames to reject.",
+        err=True,
+    )
+    raise typer.Exit(code=3)
 
 
 def discover(
@@ -72,23 +84,15 @@ def discover(
     """Save each source's schema to an auto-named schema JSON file, then serve/open the schema viewer."""
     cfg = _load_and_validate(config, discover_mode=True)
     target_dir = Path(".")
-    state = DiscoverState.load(target_dir)
 
-    sources = expand_db_sources(cfg.sources)
-    flag: str | None = None
-    if refresh:
-        flag = "refresh"
-    elif retry_failed:
-        flag = "retry-failed"
-    elif prune:
-        flag = "prune"
+    # Rename phase (only when not in refresh/prune mode — preserves prior behavior).
+    if not (refresh or prune):
+        state = DiscoverState.load(target_dir)
+        sources = expand_db_sources(cfg.sources)
+        detection = detect_renames_for_sources(state, sources)
 
-    if flag not in {"refresh", "prune"}:
-        current_pairs = [(source.name, _fingerprint_for(source)) for source in sources]
-        proposals, ambiguous = detect_renames(state=state, current=current_pairs)
-
-        if ambiguous:
-            for new_name, candidates in ambiguous:
+        if detection.ambiguous:
+            for new_name, candidates in detection.ambiguous:
                 typer.echo(
                     f"Ambiguous rename for {new_name}: candidates "
                     f"{', '.join(candidates)}",
@@ -96,82 +100,21 @@ def discover(
                 )
             raise typer.Exit(code=2)
 
-        if proposals:
-            proposal_err = not sys.stdin.isatty()
-            for old_name, new_name in proposals:
-                typer.echo(
-                    f"  Rename inferred: {old_name} -> {new_name}",
-                    err=proposal_err,
-                )
+        if detection.proposals:
+            accepted, rejected = _resolve_rename_decision(
+                detection.proposals, yes=yes, no_renames=no_renames
+            )
+            apply_rename_decision(
+                state,
+                accepted=accepted,
+                rejected=rejected,
+                sources=sources,
+                config_dir=target_dir,
+            )
+            state.save()
 
-            if no_renames:
-                for old_name, new_name in proposals:
-                    state.record_orphaned(
-                        old_name,
-                        note=f"rename rejected; new source discovered as {new_name}",
-                    )
-                    typer.echo(
-                        f"  Kept {old_name} orphaned; treating {new_name} as new"
-                    )
-            elif yes:
-                apply_renames(
-                    state=state,
-                    renames=proposals,
-                    config_dir=target_dir,
-                    sources=sources,
-                )
-            elif sys.stdin.isatty():
-                if typer.confirm("Accept all?", default=True):
-                    apply_renames(
-                        state=state,
-                        renames=proposals,
-                        config_dir=target_dir,
-                        sources=sources,
-                    )
-                else:
-                    for old_name, new_name in proposals:
-                        state.record_orphaned(
-                            old_name,
-                            note=f"rename rejected; new source discovered as {new_name}",
-                        )
-                        typer.echo(
-                            f"  Kept {old_name} orphaned; treating {new_name} as new"
-                        )
-            else:
-                typer.echo(
-                    "Rename confirmation required in non-interactive mode. "
-                    "Re-run with --yes to accept or --no-renames to reject.",
-                    err=True,
-                )
-                raise typer.Exit(code=3)
-
-    names = [s.name for s in sources]
-
-    decisions = classify(state=state, current_names=names, flag=flag)
-
-    if flag == "prune":
-        pruned = 0
-        for name, dec in list(decisions.items()):
-            entry = state.sources.get(name)
-            if dec == "removed" or (
-                entry and entry.get("status") in ("orphaned", "removed")
-            ):
-                if entry and entry.get("output_path"):
-                    target = target_dir / Path(entry["output_path"]).name
-                    if target.is_file():
-                        target.unlink()
-                        typer.echo(f"  Pruned: {target.name}")
-                state.sources.pop(name, None)
-                pruned += 1
-        state.save()
-        typer.echo(f"\nPruned {pruned} removed/orphaned entries.")
-        return
-
-    succeeded = 0
-    failed_count = 0
-    cached_count = 0
-    total = len(sources)
-
+    # Header line — match prior CLI exactly.
+    state = DiscoverState.load(target_dir)
     if state.last_run_at:
         typer.echo(
             f"Discovering from {config.name} (state file found, "
@@ -180,93 +123,48 @@ def discover(
     else:
         typer.echo(f"Discovering from {config.name}...")
 
-    for idx, source in enumerate(sources, start=1):
-        prefix = f"  [{idx}/{total}] {source.name}"
-        decision = decisions.get(source.name, "new")
-        fingerprint = _fingerprint_for(source)
+    report = run_discover(
+        cfg,
+        target_dir,
+        refresh=refresh,
+        retry_failed=retry_failed,
+        prune=prune,
+    )
 
-        if decision == "cached":
-            entry = state.sources[source.name]
-            cached_count += 1
-            typer.echo(f"{prefix}  (cached, {entry.get('table_count', 0)} tables)")
-            continue
-        if decision == "skip":
+    # Per-source line output (match prior format).
+    if prune:
+        for r in report.results:
+            if r.status == "pruned" and r.output_path is not None:
+                typer.echo(f"  Pruned: {r.output_path.name}")
+        typer.echo(f"\nPruned {report.pruned_count} removed/orphaned entries.")
+        return
+
+    total = len(report.results)
+    for idx, r in enumerate(report.results, start=1):
+        prefix = f"  [{idx}/{total}] {r.name}"
+        if r.status == "cached":
+            typer.echo(f"{prefix}  (cached, {r.table_count} tables)")
+        elif r.status == "skipped":
             typer.echo(f"{prefix}  (skipped)")
-            continue
-
-        # Source came from expand_db_sources with a pre-set error (e.g. empty enumeration).
-        if hasattr(source, "_last_error") and source._last_error:
-            failed_count += 1
-            state.record_failed(
-                name=source.name,
-                type_=source.type,
-                fingerprint=fingerprint,
-                error=source._last_error,
-                host=getattr(source, "host", None),
-                database=getattr(source, "database", None),
+        elif r.status == "failed":
+            typer.echo(f"{prefix}  → FAILED: {r.error}", err=True)
+        elif r.status == "succeeded":
+            assert r.output_path is not None
+            typer.echo(
+                f"{prefix}  ({r.decision})  → {r.table_count} tables → ./{r.output_path.name}"
             )
-            typer.echo(f"{prefix}  → FAILED: {source._last_error}", err=True)
-            continue
 
-        # "new", "retry", "rerun" — actually discover.
-        if not source.check():
-            err = getattr(source, "_last_error", "connection failed")
-            failed_count += 1
-            state.record_failed(
-                name=source.name,
-                type_=source.type,
-                fingerprint=fingerprint,
-                error=err,
-                host=getattr(source, "host", None),
-                database=getattr(source, "database", None),
-            )
-            typer.echo(f"{prefix}  → FAILED: {err}", err=True)
-            continue
-        try:
-            out, count = _write_schema(source, target_dir)
-        except Exception as e:
-            failed_count += 1
-            state.record_failed(
-                name=source.name,
-                type_=source.type,
-                fingerprint=fingerprint,
-                error=str(e),
-                host=getattr(source, "host", None),
-                database=getattr(source, "database", None),
-            )
-            typer.echo(f"{prefix}  → FAILED: {e}", err=True)
-            continue
-        succeeded += 1
-        state.record_ok(
-            name=source.name,
-            type_=source.type,
-            fingerprint=fingerprint,
-            table_count=count,
-            output_path=out,
-            host=getattr(source, "host", None),
-            database=getattr(source, "database", None),
-        )
-        label = decision
-        typer.echo(f"{prefix}  ({label})  → {count} tables → ./{out.name}")
-
-    # Mark state-only entries as removed.
-    for name, dec in decisions.items():
-        if dec == "removed" and state.sources.get(name, {}).get("status") != "orphaned":
-            state.record_removed(name)
-
-    state.save()
-
-    parts = []
-    if succeeded:
-        parts.append(f"{succeeded} discovered")
-    if cached_count:
-        parts.append(f"{cached_count} cached")
-    if failed_count:
-        parts.append(f"{failed_count} failed")
+    parts: list[str] = []
+    if report.succeeded_count:
+        parts.append(f"{report.succeeded_count} discovered")
+    if report.cached_count:
+        parts.append(f"{report.cached_count} cached")
+    if report.failed_count:
+        parts.append(f"{report.failed_count} failed")
     typer.echo(f"\n{', '.join(parts)}.")
 
     serve_and_open(target_dir.resolve(), preferred_port=8000)
-    if failed_count > 0:
+    if report.failed_count > 0:
         raise typer.Exit(code=2)
 
 

--- a/src/feather_etl/commands/history.py
+++ b/src/feather_etl/commands/history.py
@@ -1,4 +1,4 @@
-"""`feather history` command."""
+"""`feather history` command — thin Typer wrapper over feather_etl.history."""
 
 from __future__ import annotations
 
@@ -10,6 +10,8 @@ from feather_etl.commands._common import (
     _is_json,
     _load_and_validate,
 )
+from feather_etl.exceptions import StateDBMissingError
+from feather_etl.history import load_history
 from feather_etl.output import emit
 
 
@@ -20,17 +22,14 @@ def history(
     limit: int = typer.Option(20, "--limit", help="Maximum number of runs to show."),
 ) -> None:
     """Show recent run history."""
-    from feather_etl.state import StateManager
-
     cfg = _load_and_validate(config)
     state_path = cfg.config_dir / "feather_state.duckdb"
 
-    if not state_path.exists():
+    try:
+        rows = load_history(state_path, table=table, limit=limit)
+    except StateDBMissingError:
         typer.echo("No state DB found. Run 'feather run' first.", err=True)
         raise typer.Exit(code=1)
-
-    sm = StateManager(state_path)
-    rows = sm.get_history(table_name=table, limit=limit)
 
     if not rows:
         if not _is_json(ctx):

--- a/src/feather_etl/commands/setup.py
+++ b/src/feather_etl/commands/setup.py
@@ -1,4 +1,4 @@
-"""`feather setup` command."""
+"""`feather setup` command — thin Typer wrapper over feather_etl.setup."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from feather_etl.commands._common import (
     _load_and_validate,
 )
 from feather_etl.output import emit_line
+from feather_etl.setup import run_setup
 
 
 def setup(
@@ -19,45 +20,19 @@ def setup(
     mode: str | None = typer.Option(None, "--mode"),
 ) -> None:
     """Preview and initialize state DB and schemas. Optional — feather run creates them automatically."""
-    from feather_etl.destinations.duckdb import DuckDBDestination
-    from feather_etl.state import StateManager
-
     cfg = _load_and_validate(config, mode_override=mode)
     if not _is_json(ctx):
         typer.echo(f"Mode: {cfg.mode}")
 
-    state_path = cfg.config_dir / "feather_state.duckdb"
-    sm = StateManager(state_path)
-    sm.init_state()
-    if not _is_json(ctx):
-        typer.echo(f"State DB initialized: {state_path}")
+    result = run_setup(cfg)
 
-    dest = DuckDBDestination(path=cfg.destination.path)
-    dest.setup_schemas()
     if not _is_json(ctx):
-        typer.echo(f"Schemas created in: {cfg.destination.path}")
-
-    # Execute transforms (silver views, gold views/tables) if any exist
-    from feather_etl.transforms import (
-        build_execution_order,
-        discover_transforms,
-        execute_transforms,
-    )
+        typer.echo(f"State DB initialized: {result.state_db_path}")
+        typer.echo(f"Schemas created in: {result.destination_path}")
 
     transforms_applied = 0
-    transforms = discover_transforms(cfg.config_dir)
-    if transforms:
-        ordered = build_execution_order(transforms)
-        con = dest._connect()
-        try:
-            if cfg.mode == "prod":
-                gold_only = [t for t in ordered if t.schema == "gold"]
-                results = execute_transforms(con, gold_only)
-            else:
-                results = execute_transforms(con, ordered, force_views=True)
-        finally:
-            con.close()
-
+    if result.transform_results is not None:
+        results = result.transform_results
         transforms_applied = sum(1 for r in results if r.status == "success")
 
         if not _is_json(ctx):
@@ -92,8 +67,8 @@ def setup(
     if _is_json(ctx):
         emit_line(
             {
-                "state_db": str(state_path),
-                "destination": str(cfg.destination.path),
+                "state_db": str(result.state_db_path),
+                "destination": str(result.destination_path),
                 "schemas_created": True,
                 "transforms_applied": transforms_applied,
             },

--- a/src/feather_etl/commands/status.py
+++ b/src/feather_etl/commands/status.py
@@ -1,4 +1,4 @@
-"""`feather status` command."""
+"""`feather status` command — thin Typer wrapper over feather_etl.status."""
 
 from __future__ import annotations
 
@@ -10,24 +10,23 @@ from feather_etl.commands._common import (
     _is_json,
     _load_and_validate,
 )
+from feather_etl.exceptions import StateDBMissingError
 from feather_etl.output import emit
+from feather_etl.status import load_status
 
 
 def status(
     ctx: typer.Context, config: Path = typer.Option("feather.yaml", "--config")
 ) -> None:
     """Show last run status for all tables."""
-    from feather_etl.state import StateManager
-
     cfg = _load_and_validate(config)
     state_path = cfg.config_dir / "feather_state.duckdb"
 
-    if not state_path.exists():
+    try:
+        rows = load_status(state_path)
+    except StateDBMissingError:
         typer.echo("No state DB found. Run 'feather setup' first.", err=True)
         raise typer.Exit(code=1)
-
-    sm = StateManager(state_path)
-    rows = sm.get_status()
 
     if not rows:
         if _is_json(ctx):

--- a/src/feather_etl/commands/validate.py
+++ b/src/feather_etl/commands/validate.py
@@ -1,4 +1,4 @@
-"""`feather validate` command."""
+"""`feather validate` command — thin Typer wrapper over feather_etl.validate."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ from feather_etl.commands._common import (
     _load_and_validate,
 )
 from feather_etl.output import emit_line
+from feather_etl.validate import run_validate
 
 
 def validate(
@@ -19,45 +20,35 @@ def validate(
     """Validate config, test source connection, and write feather_validation.json."""
     cfg = _load_and_validate(config)
 
-    # Test source connections
-    all_ok = True
-    for source in cfg.sources:
-        source_ok = source.check()
-        if not source_ok:
-            all_ok = False
-        if not _is_json(ctx):
-            source_label = (
-                getattr(source, "path", None)
-                or getattr(source, "host", None)
-                or "configured"
-            )
-            conn_status = "connected" if source_ok else "FAILED"
-            typer.echo(f"  Source: {source.type} ({source_label}) — {conn_status}")
-            if not source_ok:
-                err = getattr(source, "_last_error", None)
-                if err:
-                    typer.echo(f"    Details: {err}", err=True)
+    report = run_validate(cfg)
+
+    if not _is_json(ctx):
+        for r in report.sources:
+            conn_status = "connected" if r.ok else "FAILED"
+            typer.echo(f"  Source: {r.type} ({r.label}) — {conn_status}")
+            if not r.ok and r.error:
+                typer.echo(f"    Details: {r.error}", err=True)
 
     if _is_json(ctx):
         emit_line(
             {
                 "valid": True,
-                "tables_count": len(cfg.tables),
+                "tables_count": report.tables_count,
                 "source_type": cfg.sources[0].type,
                 "destination": str(cfg.destination.path),
                 "mode": cfg.mode,
-                "source_connected": all_ok,
+                "source_connected": report.all_ok,
             },
             json_mode=True,
         )
     else:
-        typer.echo(f"Config valid: {len(cfg.tables)} table(s)")
+        typer.echo(f"Config valid: {report.tables_count} table(s)")
         typer.echo(f"  Destination: {cfg.destination.path}")
         typer.echo(f"  State: {cfg.config_dir / 'feather_state.duckdb'}")
         for t in cfg.tables:
             typer.echo(f"  Table: {t.name} → {t.target_table} ({t.strategy})")
 
-    if not all_ok:
+    if not report.all_ok:
         typer.echo("Source connection failed.", err=True)
         raise typer.Exit(code=2)
 

--- a/src/feather_etl/discover.py
+++ b/src/feather_etl/discover.py
@@ -1,0 +1,297 @@
+"""`feather discover` core — orchestration without Typer.
+
+Three pure top-level functions:
+
+* ``detect_renames_for_sources(state, sources) -> RenameDetection``
+  Pure detection. Returns proposals + ambiguous list. No I/O.
+
+* ``apply_rename_decision(state, accepted, rejected, sources, config_dir) -> None``
+  Applies a pre-resolved decision. The CLI wrapper resolves the decision
+  interactively (Typer confirm prompt + --yes / --no-renames) and calls this.
+
+* ``run_discover(cfg, config_dir, *, refresh, retry_failed, prune) -> DiscoverReport``
+  Per-source discovery loop. Assumes renames already resolved.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from feather_etl.config import FeatherConfig, schema_output_path
+from feather_etl.discover_state import (
+    DiscoverState,
+    apply_renames,
+    classify,
+    detect_renames,
+)
+
+
+@dataclass
+class RenameDetection:
+    """Output of ``detect_renames_for_sources``."""
+
+    proposals: list[tuple[str, str]] = field(default_factory=list)
+    ambiguous: list[tuple[str, list[str]]] = field(default_factory=list)
+
+
+@dataclass
+class SourceDiscoveryResult:
+    """One source's outcome from ``run_discover``."""
+
+    name: str
+    decision: str  # "new" | "retry" | "rerun" | "cached" | "skip" | "removed"
+    status: str  # "succeeded" | "failed" | "cached" | "skipped" | "pruned"
+    table_count: int = 0
+    output_path: Path | None = None
+    error: str | None = None
+
+
+@dataclass
+class DiscoverReport:
+    """Aggregate result of ``run_discover``."""
+
+    results: list[SourceDiscoveryResult] = field(default_factory=list)
+    succeeded_count: int = 0
+    failed_count: int = 0
+    cached_count: int = 0
+    pruned_count: int = 0
+    state_last_run_at: str | None = None
+
+
+def _write_schema(source, target_dir: Path) -> tuple[Path, int]:
+    """Discover ``source`` and write its schema JSON. Returns (path, table_count)."""
+    schemas = source.discover()
+    payload = [
+        {
+            "table_name": s.name,
+            "columns": [{"name": c[0], "type": c[1]} for c in s.columns],
+        }
+        for s in schemas
+    ]
+    out = target_dir / schema_output_path(source)
+    out.write_text(json.dumps(payload, indent=2))
+    return out, len(schemas)
+
+
+def _fingerprint_for(source) -> str:
+    """Composition per spec §6.7.
+
+    DB sources: '<type>:<host>:<port>:<database>'. File sources: '<type>:<absolute_path>'.
+    """
+    if hasattr(source, "host") and source.host is not None:
+        return (
+            f"{source.type}:{source.host}:{source.port or ''}:{source.database or ''}"
+        )
+    return f"{source.type}:{Path(source.path).resolve()}"
+
+
+def detect_renames_for_sources(
+    state: DiscoverState,
+    sources: list,
+) -> RenameDetection:
+    """Pure detection. Returns proposals + ambiguous list. No I/O, no prompts."""
+    current_pairs = [(source.name, _fingerprint_for(source)) for source in sources]
+    proposals, ambiguous = detect_renames(state=state, current=current_pairs)
+    return RenameDetection(proposals=list(proposals), ambiguous=list(ambiguous))
+
+
+def apply_rename_decision(
+    state: DiscoverState,
+    accepted: list[tuple[str, str]],
+    rejected: list[tuple[str, str]],
+    sources: list,
+    config_dir: Path,
+) -> None:
+    """Apply a pre-resolved rename decision.
+
+    ``accepted`` proposals are applied via ``apply_renames`` (state + files
+    are renamed). ``rejected`` proposals are recorded as orphaned (the new
+    name is treated as a fresh source on the next discovery pass).
+    """
+    if accepted:
+        apply_renames(
+            state=state,
+            renames=accepted,
+            config_dir=config_dir,
+            sources=sources,
+        )
+    for old_name, new_name in rejected:
+        state.record_orphaned(
+            old_name,
+            note=f"rename rejected; new source discovered as {new_name}",
+        )
+
+
+def run_discover(
+    cfg: FeatherConfig,
+    config_dir: Path,
+    *,
+    refresh: bool,
+    retry_failed: bool,
+    prune: bool,
+) -> DiscoverReport:
+    """Per-source discovery loop. Assumes renames already resolved.
+
+    The CLI wrapper is responsible for:
+      * resolving rename proposals (interactive or via --yes / --no-renames)
+        and calling ``apply_rename_decision`` before invoking this function;
+      * exiting with code 2 on ambiguous renames (using ``RenameDetection``);
+      * calling ``serve_and_open`` after this function returns.
+    """
+    from feather_etl.sources.expand import expand_db_sources
+
+    state = DiscoverState.load(config_dir)
+    sources = expand_db_sources(cfg.sources)
+
+    flag: str | None = None
+    if refresh:
+        flag = "refresh"
+    elif retry_failed:
+        flag = "retry-failed"
+    elif prune:
+        flag = "prune"
+
+    names = [s.name for s in sources]
+    decisions = classify(state=state, current_names=names, flag=flag)
+
+    report = DiscoverReport(state_last_run_at=state.last_run_at)
+
+    if flag == "prune":
+        for name, dec in list(decisions.items()):
+            entry = state.sources.get(name)
+            if dec == "removed" or (
+                entry and entry.get("status") in ("orphaned", "removed")
+            ):
+                output_path: Path | None = None
+                if entry and entry.get("output_path"):
+                    target = config_dir / Path(entry["output_path"]).name
+                    if target.is_file():
+                        output_path = target
+                        target.unlink()
+                state.sources.pop(name, None)
+                report.pruned_count += 1
+                report.results.append(
+                    SourceDiscoveryResult(
+                        name=name,
+                        decision=dec,
+                        status="pruned",
+                        output_path=output_path,
+                    )
+                )
+        state.save()
+        return report
+
+    for source in sources:
+        decision = decisions.get(source.name, "new")
+        fingerprint = _fingerprint_for(source)
+
+        if decision == "cached":
+            entry = state.sources[source.name]
+            report.cached_count += 1
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="cached",
+                    table_count=entry.get("table_count", 0),
+                )
+            )
+            continue
+        if decision == "skip":
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name, decision=decision, status="skipped"
+                )
+            )
+            continue
+
+        # Source came from expand_db_sources with a pre-set error.
+        if hasattr(source, "_last_error") and source._last_error:
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=source._last_error,
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="failed",
+                    error=source._last_error,
+                )
+            )
+            continue
+
+        if not source.check():
+            err = getattr(source, "_last_error", "connection failed")
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=err,
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name, decision=decision, status="failed", error=err
+                )
+            )
+            continue
+
+        try:
+            out, count = _write_schema(source, config_dir)
+        except Exception as e:  # noqa: BLE001 — preserve existing broad-catch behavior
+            report.failed_count += 1
+            state.record_failed(
+                name=source.name,
+                type_=source.type,
+                fingerprint=fingerprint,
+                error=str(e),
+                host=getattr(source, "host", None),
+                database=getattr(source, "database", None),
+            )
+            report.results.append(
+                SourceDiscoveryResult(
+                    name=source.name,
+                    decision=decision,
+                    status="failed",
+                    error=str(e),
+                )
+            )
+            continue
+
+        report.succeeded_count += 1
+        state.record_ok(
+            name=source.name,
+            type_=source.type,
+            fingerprint=fingerprint,
+            table_count=count,
+            output_path=out,
+            host=getattr(source, "host", None),
+            database=getattr(source, "database", None),
+        )
+        report.results.append(
+            SourceDiscoveryResult(
+                name=source.name,
+                decision=decision,
+                status="succeeded",
+                table_count=count,
+                output_path=out,
+            )
+        )
+
+    # Mark state-only entries as removed (preserves prior CLI behavior).
+    for name, dec in decisions.items():
+        if dec == "removed" and state.sources.get(name, {}).get("status") != "orphaned":
+            state.record_removed(name)
+
+    state.save()
+    return report

--- a/src/feather_etl/exceptions.py
+++ b/src/feather_etl/exceptions.py
@@ -1,0 +1,7 @@
+"""Shared domain exceptions for feather-etl core modules."""
+
+from __future__ import annotations
+
+
+class StateDBMissingError(Exception):
+    """Raised when an operation requires the state DB but it does not exist on disk."""

--- a/src/feather_etl/history.py
+++ b/src/feather_etl/history.py
@@ -1,0 +1,26 @@
+"""`feather history` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.exceptions import StateDBMissingError
+
+
+def load_history(
+    state_path: Path,
+    *,
+    table: str | None = None,
+    limit: int = 20,
+) -> list[dict]:
+    """Return recent run history rows from the state DB.
+
+    Raises ``StateDBMissingError`` if the state DB does not exist.
+    """
+    if not state_path.exists():
+        raise StateDBMissingError(str(state_path))
+
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    return sm.get_history(table_name=table, limit=limit)

--- a/src/feather_etl/setup.py
+++ b/src/feather_etl/setup.py
@@ -1,0 +1,62 @@
+"""`feather setup` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from feather_etl.config import FeatherConfig
+from feather_etl.transforms import TransformResult
+
+
+@dataclass
+class SetupResult:
+    """Result of running `feather setup` against a loaded config."""
+
+    state_db_path: Path
+    destination_path: Path
+    transform_results: list[TransformResult] | None  # None if no transforms found
+
+
+def run_setup(cfg: FeatherConfig) -> SetupResult:
+    """Initialize state DB, create destination schemas, execute transforms.
+
+    Returns a ``SetupResult`` describing what was created. Transforms are
+    executed if any are discovered in ``<config_dir>/transforms/``. In prod
+    mode, only gold transforms are executed; in dev mode, all transforms are
+    executed with ``force_views=True`` (matches the prior CLI behavior).
+    """
+    from feather_etl.destinations.duckdb import DuckDBDestination
+    from feather_etl.state import StateManager
+    from feather_etl.transforms import (
+        build_execution_order,
+        discover_transforms,
+        execute_transforms,
+    )
+
+    state_path = cfg.config_dir / "feather_state.duckdb"
+    sm = StateManager(state_path)
+    sm.init_state()
+
+    dest = DuckDBDestination(path=cfg.destination.path)
+    dest.setup_schemas()
+
+    transform_results: list[TransformResult] | None = None
+    transforms = discover_transforms(cfg.config_dir)
+    if transforms:
+        ordered = build_execution_order(transforms)
+        con = dest._connect()
+        try:
+            if cfg.mode == "prod":
+                gold_only = [t for t in ordered if t.schema == "gold"]
+                transform_results = execute_transforms(con, gold_only)
+            else:
+                transform_results = execute_transforms(con, ordered, force_views=True)
+        finally:
+            con.close()
+
+    return SetupResult(
+        state_db_path=state_path,
+        destination_path=cfg.destination.path,
+        transform_results=transform_results,
+    )

--- a/src/feather_etl/status.py
+++ b/src/feather_etl/status.py
@@ -1,0 +1,21 @@
+"""`feather status` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from feather_etl.exceptions import StateDBMissingError
+
+
+def load_status(state_path: Path) -> list[dict[str, object]]:
+    """Return per-table last-run status rows from the state DB.
+
+    Raises ``StateDBMissingError`` if the state DB does not exist.
+    """
+    if not state_path.exists():
+        raise StateDBMissingError(str(state_path))
+
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    return sm.get_status()

--- a/src/feather_etl/validate.py
+++ b/src/feather_etl/validate.py
@@ -1,0 +1,53 @@
+"""`feather validate` core — orchestration without Typer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from feather_etl.config import FeatherConfig
+
+
+@dataclass
+class SourceCheckResult:
+    """Connection-check result for a single source."""
+
+    type: str
+    label: str  # path or host, whichever the source exposes; "configured" otherwise
+    ok: bool
+    error: str | None  # source._last_error when ok is False
+
+
+@dataclass
+class ValidateReport:
+    """Result of running `feather validate` against a loaded config."""
+
+    sources: list[SourceCheckResult]
+    tables_count: int
+    all_ok: bool
+
+
+def run_validate(cfg: FeatherConfig) -> ValidateReport:
+    """Test connection for each configured source. Pure read; no side effects."""
+    results: list[SourceCheckResult] = []
+    for source in cfg.sources:
+        ok = source.check()
+        label = (
+            getattr(source, "path", None)
+            or getattr(source, "host", None)
+            or "configured"
+        )
+        error = getattr(source, "_last_error", None) if not ok else None
+        results.append(
+            SourceCheckResult(
+                type=source.type,
+                label=str(label),
+                ok=ok,
+                error=error,
+            )
+        )
+
+    return ValidateReport(
+        sources=results,
+        tables_count=len(cfg.tables),
+        all_ok=all(r.ok for r in results),
+    )

--- a/tests/commands/test_discover.py
+++ b/tests/commands/test_discover.py
@@ -283,6 +283,49 @@ class TestDiscover:
 
 
 @pytest.mark.usefixtures("stub_viewer_serve")
+class TestDiscoverPruneOutput:
+    """Regression: --prune must NOT emit the 'Discovering from ...' header.
+
+    The pre-refactor wrapper short-circuited prune mode before the header
+    block. The Task 7 extraction accidentally moved the header above the
+    short-circuit. Lock the contract here.
+    """
+
+    def test_prune_does_not_emit_discovering_header(
+        self, runner, tmp_path, monkeypatch
+    ):
+        from feather_etl.cli import app
+        from feather_etl.discover_state import DiscoverState
+
+        config_path = _write_sqlite_config(tmp_path)
+        monkeypatch.chdir(tmp_path)
+
+        # Seed a state entry for a now-removed source with a file on disk,
+        # so prune actually has work to do.
+        state = DiscoverState.load(tmp_path)
+        old_path = tmp_path / "schemas-sqlite-stale.json"
+        old_path.write_text("[]")
+        state.record_ok(
+            name="stale",
+            type_="sqlite",
+            fingerprint="sqlite:/non/existent",
+            table_count=1,
+            output_path=old_path,
+        )
+        state.save()
+
+        result = runner.invoke(app, ["discover", "--config", str(config_path), "--prune"])
+
+        assert result.exit_code == 0
+        assert "Discovering from" not in result.output, (
+            f"--prune must not emit the 'Discovering from' header.\n"
+            f"Got output:\n{result.output}"
+        )
+        assert "Pruned: schemas-sqlite-stale.json" in result.output
+        assert "Pruned 1 removed/orphaned entries." in result.output
+
+
+@pytest.mark.usefixtures("stub_viewer_serve")
 class TestDiscoverAutoEnumPermissionError:
     def test_empty_enumeration_records_failed_with_hint(
         self, runner, tmp_path, monkeypatch

--- a/tests/test_core_module_purity.py
+++ b/tests/test_core_module_purity.py
@@ -1,0 +1,39 @@
+"""Purity test: pure-core modules must not import Typer.
+
+The split between `commands/<name>.py` (Typer-aware CLI wrapper) and
+`<name>.py` (pure orchestration) is a load-bearing architectural
+constraint enforced here. If you find yourself wanting to add `typer`
+to a module in this list, the split is wrong — push the Typer concern
+back into the corresponding `commands/<name>.py` wrapper instead.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+CORE_MODULES = [
+    "feather_etl.pipeline",
+    "feather_etl.cache",
+    "feather_etl.viewer_server",
+    "feather_etl.init_wizard",
+    "feather_etl.exceptions",
+    "feather_etl.history",
+    "feather_etl.status",
+]
+
+
+@pytest.mark.parametrize("module_name", CORE_MODULES)
+def test_core_module_does_not_import_typer(module_name: str) -> None:
+    module = importlib.import_module(module_name)
+    source = inspect.getsource(module)
+    assert "import typer" not in source, (
+        f"{module_name} must not import typer — push the Typer concern "
+        f"into the corresponding commands/<name>.py wrapper."
+    )
+    assert "from typer" not in source, (
+        f"{module_name} must not import from typer — push the Typer concern "
+        f"into the corresponding commands/<name>.py wrapper."
+    )

--- a/tests/test_core_module_purity.py
+++ b/tests/test_core_module_purity.py
@@ -24,6 +24,7 @@ CORE_MODULES = [
     "feather_etl.status",
     "feather_etl.validate",
     "feather_etl.setup",
+    "feather_etl.discover",
 ]
 
 

--- a/tests/test_core_module_purity.py
+++ b/tests/test_core_module_purity.py
@@ -22,6 +22,7 @@ CORE_MODULES = [
     "feather_etl.exceptions",
     "feather_etl.history",
     "feather_etl.status",
+    "feather_etl.validate",
 ]
 
 

--- a/tests/test_core_module_purity.py
+++ b/tests/test_core_module_purity.py
@@ -23,6 +23,7 @@ CORE_MODULES = [
     "feather_etl.history",
     "feather_etl.status",
     "feather_etl.validate",
+    "feather_etl.setup",
 ]
 
 

--- a/tests/test_discover_core.py
+++ b/tests/test_discover_core.py
@@ -1,0 +1,310 @@
+"""Direct unit tests for feather_etl.discover top-level functions."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+
+
+def _make_sqlite_project(tmp_path: Path, source_name: str | None = None) -> Path:
+    """Set up a tmp SQLite feather project. Returns config path."""
+    shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+    source: dict = {"type": "sqlite", "path": "./source.sqlite"}
+    if source_name is not None:
+        source["name"] = source_name
+    cfg = {
+        "sources": [source],
+        "destination": {"path": "./feather_data.duckdb"},
+        "tables": [
+            {
+                "name": "orders",
+                "source_table": "orders",
+                "target_table": "bronze.orders",
+                "strategy": "full",
+            }
+        ],
+    }
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(cfg))
+    return config_path
+
+
+class TestDetectRenamesForSources:
+    def test_returns_empty_proposals_when_state_is_empty(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        cfg = load_config(_make_sqlite_project(tmp_path), validate=False)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == []
+        assert detection.ambiguous == []
+
+    def test_finds_rename_when_fingerprint_matches_under_new_name(self, tmp_path: Path):
+        """Rename a source in YAML; same fingerprint → proposal."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        # First load with name "old_db" — record state.
+        config_path = _make_sqlite_project(tmp_path, source_name="old_db")
+        cfg = load_config(config_path, validate=False)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        # Simulate a prior successful discover under "old_db".
+        from feather_etl.discover import _fingerprint_for
+
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=_fingerprint_for(sources[0]),
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_db.json",
+        )
+
+        # Now rename source to "new_db".
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path, validate=False)
+        sources = expand_db_sources(cfg.sources)
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == [("old_db", "new_db")]
+        assert detection.ambiguous == []
+
+    def test_returns_ambiguous_when_multiple_state_entries_match(self, tmp_path: Path):
+        """Two stale state entries with the same fingerprint as one current
+        source → ambiguous (cannot decide which old name was renamed)."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import _fingerprint_for, detect_renames_for_sources
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path, validate=False)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        state.record_ok(
+            name="old_a",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_a.json",
+        )
+        state.record_ok(
+            name="old_b",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_b.json",
+        )
+
+        detection = detect_renames_for_sources(state, sources)
+
+        assert detection.proposals == []
+        assert len(detection.ambiguous) == 1
+        new_name, candidates = detection.ambiguous[0]
+        assert new_name == "new_db"
+        assert set(candidates) == {"old_a", "old_b"}
+
+
+class TestApplyRenameDecision:
+    def test_renames_state_and_files_for_accepted_proposals(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import (
+            _fingerprint_for,
+            apply_rename_decision,
+        )
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path, validate=False)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        old_path = tmp_path / "schemas-sqlite-old_db.json"
+        old_path.write_text("[]")
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=old_path,
+        )
+
+        apply_rename_decision(
+            state,
+            accepted=[("old_db", "new_db")],
+            rejected=[],
+            sources=sources,
+            config_dir=tmp_path,
+        )
+
+        assert "new_db" in state.sources
+        assert "old_db" not in state.sources
+
+    def test_marks_orphaned_for_rejected_proposals(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import _fingerprint_for, apply_rename_decision
+        from feather_etl.discover_state import DiscoverState
+        from feather_etl.sources.expand import expand_db_sources
+
+        config_path = _make_sqlite_project(tmp_path, source_name="new_db")
+        cfg = load_config(config_path, validate=False)
+        state = DiscoverState.load(tmp_path)
+        sources = expand_db_sources(cfg.sources)
+        fp = _fingerprint_for(sources[0])
+        state.record_ok(
+            name="old_db",
+            type_=sources[0].type,
+            fingerprint=fp,
+            table_count=1,
+            output_path=tmp_path / "schemas-sqlite-old_db.json",
+        )
+
+        apply_rename_decision(
+            state,
+            accepted=[],
+            rejected=[("old_db", "new_db")],
+            sources=sources,
+            config_dir=tmp_path,
+        )
+
+        assert state.sources["old_db"].get("status") == "orphaned"
+
+
+class TestRunDiscover:
+    def test_records_succeeded_sources_with_table_counts(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path), validate=False)
+
+        report = run_discover(
+            cfg,
+            tmp_path,
+            refresh=False,
+            retry_failed=False,
+            prune=False,
+        )
+
+        assert report.succeeded_count == 1
+        assert report.failed_count == 0
+        assert len(report.results) == 1
+        r = report.results[0]
+        assert r.status == "succeeded"
+        assert r.table_count > 0
+        assert r.output_path is not None
+        assert r.output_path.exists()
+
+    def test_records_failed_sources_with_error_message(self, tmp_path: Path):
+        """Source pointing at a missing file → failed, error captured in result."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        # Build config with a deliberately missing SQLite file.
+        cfg_dict = {
+            "sources": [{"type": "sqlite", "path": "./missing.sqlite"}],
+            "destination": {"path": "./feather_data.duckdb"},
+            "tables": [
+                {
+                    "name": "orders",
+                    "source_table": "orders",
+                    "target_table": "bronze.orders",
+                    "strategy": "full",
+                }
+            ],
+        }
+        config_path = tmp_path / "feather.yaml"
+        config_path.write_text(yaml.dump(cfg_dict))
+        # discover_mode skips table validation
+        cfg = load_config(config_path, validate=False)
+
+        report = run_discover(
+            cfg,
+            tmp_path,
+            refresh=False,
+            retry_failed=False,
+            prune=False,
+        )
+
+        assert report.failed_count == 1
+        assert report.succeeded_count == 0
+        assert report.results[0].status == "failed"
+        assert report.results[0].error is not None
+
+    def test_with_refresh_ignores_cached_state(self, tmp_path: Path):
+        """A second run with refresh=True re-discovers a previously-discovered source."""
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path), validate=False)
+
+        # First run — establishes state.
+        run_discover(cfg, tmp_path, refresh=False, retry_failed=False, prune=False)
+
+        # Second run with refresh — should re-discover, not return cached.
+        report = run_discover(
+            cfg, tmp_path, refresh=True, retry_failed=False, prune=False
+        )
+
+        assert report.succeeded_count == 1
+        assert report.cached_count == 0
+
+    def test_second_run_without_refresh_reports_cached(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+
+        cfg = load_config(_make_sqlite_project(tmp_path), validate=False)
+
+        run_discover(cfg, tmp_path, refresh=False, retry_failed=False, prune=False)
+        report = run_discover(
+            cfg, tmp_path, refresh=False, retry_failed=False, prune=False
+        )
+
+        assert report.cached_count == 1
+        assert report.succeeded_count == 0
+
+    def test_with_prune_removes_state_and_files_for_removed_sources(
+        self, tmp_path: Path
+    ):
+        from feather_etl.config import load_config
+        from feather_etl.discover import run_discover
+        from feather_etl.discover_state import DiscoverState
+
+        cfg = load_config(_make_sqlite_project(tmp_path), validate=False)
+
+        # Seed a state entry for a now-removed source with a file on disk.
+        state = DiscoverState.load(tmp_path)
+        old_path = tmp_path / "schemas-sqlite-stale.json"
+        old_path.write_text("[]")
+        state.record_ok(
+            name="stale",
+            type_="sqlite",
+            fingerprint="sqlite:/non/existent",
+            table_count=1,
+            output_path=old_path,
+        )
+        state.save()
+
+        report = run_discover(
+            cfg, tmp_path, refresh=False, retry_failed=False, prune=True
+        )
+
+        assert report.pruned_count >= 1
+        assert not old_path.exists()
+
+        state = DiscoverState.load(tmp_path)
+        assert "stale" not in state.sources

--- a/tests/test_history_core.py
+++ b/tests/test_history_core.py
@@ -1,0 +1,77 @@
+"""Direct unit tests for feather_etl.history.load_history()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _make_state_with_runs(state_path: Path) -> None:
+    """Create a state DB and insert two run rows."""
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    sm.init_state()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sm.record_run(
+        run_id="run-1",
+        table_name="orders",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=10,
+    )
+    sm.record_run(
+        run_id="run-2",
+        table_name="customers",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=5,
+    )
+
+
+class TestLoadHistory:
+    def test_returns_rows_from_state_db(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path)
+
+        assert len(rows) == 2
+        assert {r["table_name"] for r in rows} == {"orders", "customers"}
+        assert all(r["status"] == "success" for r in rows)
+
+    def test_filters_by_table_name(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path, table="orders")
+
+        assert len(rows) == 1
+        assert rows[0]["table_name"] == "orders"
+
+    def test_respects_limit(self, tmp_path: Path):
+        from feather_etl.history import load_history
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_history(state_path, limit=1)
+
+        assert len(rows) == 1
+
+
+class TestLoadHistoryPreconditions:
+    def test_raises_state_db_missing_when_no_db(self, tmp_path: Path):
+        from feather_etl.exceptions import StateDBMissingError
+        from feather_etl.history import load_history
+
+        with pytest.raises(StateDBMissingError):
+            load_history(tmp_path / "missing.duckdb")

--- a/tests/test_setup_core.py
+++ b/tests/test_setup_core.py
@@ -1,0 +1,83 @@
+"""Direct unit tests for feather_etl.setup.run_setup()."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
+
+
+def _make_project(tmp_path: Path, *, mode: str | None = None) -> Path:
+    """Build a minimal feather project. Returns config path.
+
+    Note: ``load_config`` reads tables from ``discovery/curation.json``, not from
+    the YAML, so the project layout uses ``write_curation`` (the same pattern as
+    ``tests/commands/conftest.py::cli_env``).
+    """
+    shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+    config: dict = {
+        "sources": [{"type": "sqlite", "name": "erp", "path": "./source.sqlite"}],
+        "destination": {"path": "./feather_data.duckdb"},
+    }
+    if mode is not None:
+        config["mode"] = mode
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(config))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "orders", "orders")],
+    )
+    return config_path
+
+
+def _write_silver_transform(tmp_path: Path) -> None:
+    """Write a tiny silver view definition that depends on bronze.orders."""
+    tdir = tmp_path / "transforms" / "silver"
+    tdir.mkdir(parents=True, exist_ok=True)
+    (tdir / "orders_clean.sql").write_text(
+        "CREATE OR REPLACE VIEW silver.orders_clean AS SELECT * FROM bronze.orders;\n"
+    )
+
+
+class TestRunSetup:
+    def test_initializes_state_db_and_destination(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        cfg = load_config(_make_project(tmp_path))
+
+        result = run_setup(cfg)
+
+        assert result.state_db_path.exists()
+        assert result.destination_path == cfg.destination.path
+        assert result.transform_results is None  # no transforms in this project
+
+    def test_returns_none_transforms_when_no_transforms_found(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        cfg = load_config(_make_project(tmp_path))
+        result = run_setup(cfg)
+
+        assert result.transform_results is None
+
+    def test_executes_transforms_when_present(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.setup import run_setup
+
+        config_path = _make_project(tmp_path)
+        _write_silver_transform(tmp_path)
+        cfg = load_config(config_path)
+
+        result = run_setup(cfg)
+
+        assert result.transform_results is not None
+        assert len(result.transform_results) >= 1
+        assert any(
+            t.name == "orders_clean" and t.schema == "silver"
+            for t in result.transform_results
+        )

--- a/tests/test_status_core.py
+++ b/tests/test_status_core.py
@@ -1,0 +1,66 @@
+"""Direct unit tests for feather_etl.status.load_status()."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+def _make_state_with_runs(state_path: Path) -> None:
+    """Create a state DB and insert run rows for two tables."""
+    from feather_etl.state import StateManager
+
+    sm = StateManager(state_path)
+    sm.init_state()
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    sm.record_run(
+        run_id="run-1",
+        table_name="orders",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=10,
+    )
+    sm.record_run(
+        run_id="run-2",
+        table_name="customers",
+        started_at=now,
+        ended_at=now,
+        status="success",
+        rows_loaded=5,
+    )
+
+
+class TestLoadStatus:
+    def test_returns_rows_for_each_table(self, tmp_path: Path):
+        from feather_etl.status import load_status
+
+        state_path = tmp_path / "feather_state.duckdb"
+        _make_state_with_runs(state_path)
+
+        rows = load_status(state_path)
+
+        assert {r["table_name"] for r in rows} == {"orders", "customers"}
+
+    def test_returns_empty_list_when_no_runs(self, tmp_path: Path):
+        from feather_etl.state import StateManager
+        from feather_etl.status import load_status
+
+        state_path = tmp_path / "feather_state.duckdb"
+        sm = StateManager(state_path)
+        sm.init_state()
+
+        rows = load_status(state_path)
+
+        assert rows == []
+
+
+class TestLoadStatusPreconditions:
+    def test_raises_state_db_missing_when_no_db(self, tmp_path: Path):
+        from feather_etl.exceptions import StateDBMissingError
+        from feather_etl.status import load_status
+
+        with pytest.raises(StateDBMissingError):
+            load_status(tmp_path / "missing.duckdb")

--- a/tests/test_validate_core.py
+++ b/tests/test_validate_core.py
@@ -1,0 +1,93 @@
+"""Direct unit tests for feather_etl.validate.run_validate()."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import yaml
+
+from tests.conftest import FIXTURES_DIR
+from tests.helpers import make_curation_entry, write_curation
+
+
+def _make_sqlite_project(tmp_path: Path, *, valid_path: bool = True) -> Path:
+    """Build a minimal feather project with a SQLite source. Returns config path."""
+    if valid_path:
+        shutil.copy2(FIXTURES_DIR / "sample_erp.sqlite", tmp_path / "source.sqlite")
+        source_path = "./source.sqlite"
+    else:
+        source_path = "./missing.sqlite"
+
+    config = {
+        "sources": [{"type": "sqlite", "name": "erp", "path": source_path}],
+        "destination": {"path": "./feather_data.duckdb"},
+    }
+    config_path = tmp_path / "feather.yaml"
+    config_path.write_text(yaml.dump(config))
+    write_curation(
+        tmp_path,
+        [make_curation_entry("erp", "orders", "orders")],
+    )
+    return config_path
+
+
+class TestRunValidate:
+    def test_reports_each_source_status_when_all_ok(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+        report = run_validate(cfg)
+
+        assert report.all_ok is True
+        assert report.tables_count == 1
+        assert len(report.sources) == 1
+        assert report.sources[0].type == "sqlite"
+        assert report.sources[0].ok is True
+        assert report.sources[0].error is None
+
+    def test_returns_all_ok_false_when_any_source_check_fails(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path, valid_path=False))
+        report = run_validate(cfg)
+
+        assert report.all_ok is False
+        assert report.sources[0].ok is False
+
+    def test_propagates_last_error_for_failed_sources(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+
+        # Replace the source with a fake that fails with a diagnostic error —
+        # mirrors the real-world case (DB sources set `_last_error` on failure)
+        # that the `validate` command surfaces as "Details: ...".
+        class FakeFailingSource:
+            type = "duckdb"
+            path = "/nope.duckdb"
+
+            def __init__(self) -> None:
+                self._last_error = "TLS Provider: certificate verify failed"
+
+            def check(self) -> bool:
+                return False
+
+        cfg.sources[0] = FakeFailingSource()
+        report = run_validate(cfg)
+
+        assert report.sources[0].ok is False
+        assert report.sources[0].error == "TLS Provider: certificate verify failed"
+
+    def test_label_uses_path_for_file_sources(self, tmp_path: Path):
+        from feather_etl.config import load_config
+        from feather_etl.validate import run_validate
+
+        cfg = load_config(_make_sqlite_project(tmp_path))
+        report = run_validate(cfg)
+
+        # File-based sources expose `path` — the label should be the path.
+        assert "source.sqlite" in str(report.sources[0].label)


### PR DESCRIPTION
Closes #43.

## What this does

Refactors `commands/<name>.py` modules to follow the established **thin Typer wrapper ↔ pure top-level core** pattern proven by `commands/run.py` ↔ `pipeline.py` and `commands/cache.py` ↔ `cache.py`.

Five new pure-core modules introduced under `src/feather_etl/`:

| Module | Public API |
|---|---|
| `exceptions.py` | `StateDBMissingError` (shared) |
| `history.py` | `load_history(state_path, *, table=None, limit=20)` |
| `status.py` | `load_status(state_path)` |
| `validate.py` | `run_validate(cfg) -> ValidateReport`, `SourceCheckResult` |
| `setup.py` | `run_setup(cfg) -> SetupResult` |
| `discover.py` | `detect_renames_for_sources()`, `apply_rename_decision()`, `run_discover() -> DiscoverReport` (split into 3 pure functions) |

Five wrappers under `commands/` rewritten to delegate, dropping ~290 lines of mixed concerns.

**Constraint that matters:** none of the new top-level cores import `typer`. This is enforced by a new parametrized purity test (`tests/test_core_module_purity.py`) over 10 modules — the issue's manual `grep` check encoded as code.

## Why

Per #43:
- Testable core logic without the Typer runtime — direct unit tests instead of going through `CliRunner`
- Reusable cores — a future MCP/HTTP/library layer can call them without re-implementing orchestration
- Readability — `commands/discover.py` shrinks from 274 → 167 lines with one concern per file
- Generalizes a pattern already proven by two existing modules

## How

Implemented per the design at `docs/superpowers/specs/2026-04-19-thin-cli-refactor-design.md` and the implementation plan at `docs/superpowers/plans/2026-04-19-thin-cli-refactor.md`.

Easiest-first sequencing — `history` → `status` → purity test → `init` verify (no-op) → `validate` → `setup` → `discover`. TDD throughout: failing core test → minimal core → green → wrapper rewrite → full suite green → commit.

Each task got two-stage review (spec compliance, then code quality). The discover extraction surfaced one **prune-mode regression** in code review — fixed in-branch with a regression-locking test (commit `16d739f`). See "Behavior preservation" below.

## Convention for the new cores

Documented in the spec, applied throughout:

| Concern | How the core handles it |
|---|---|
| Per-item failure across many items | `status="failure"` entry in result list. Don't raise. CLI sums and decides exit code. |
| Fatal preconditions (config not found, state DB missing, prod-mode guard) | Raise a domain exception. CLI catches and translates to `typer.echo(err) + Exit(code)`. |
| Pure read-through (history, status) | Return `list[dict[str, object]]` from `StateManager`. Precondition raises `StateDBMissingError`. |
| Multi-stage orchestration (validate, setup, discover) | Return a small dataclass carrying counts/items. |
| User interaction (prompts, `typer.confirm`) | Stays in CLI wrapper. Core takes pre-resolved values, never callbacks. |

## Behavior preservation

This is the whole point of the refactor — every `feather <cmd> --flag` invocation produces byte-identical stdout/stderr, identical exit codes, identical JSON output, identical prompts.

- All existing CLI test suites still pass (`tests/commands/*`)
- Test count: **653 → 688** (+35 tests: 32 new direct-unit tests + 1 prune regression test + 2 minor)
- Five new core modules confirmed `typer`-free by the purity test
- Hands-on suite (`scripts/hands_on_test.sh`) — see "Out of scope" below

### Discover prune regression — caught in-branch

Code review surfaced two subtle regressions in the Task 7 discover extraction:

1. The pre-refactor wrapper short-circuited `--prune` BEFORE the `Discovering from <config>...` header. The extraction accidentally moved the header above the prune branch.
2. When renames were detected, the rename phase's `state.save()` updates `last_run_at` to now. The wrapper then re-loaded state and showed the rename's timestamp instead of the truly-prior discover's timestamp.

The pre-existing CLI suite had **zero** coverage of `--prune` output, which is why the regression slipped through Task 7's existing tests. Fixed in commit `16d739f` with a `TestDiscoverPruneOutput::test_prune_does_not_emit_discovering_header` regression test that locks both contracts.

This is a positive demonstration of the refactor's value: extracting the core forced us to look at orchestration in isolation and revealed a behavior gap in the existing test coverage.

## Plan-fix commits

Two `docs(plan): ...` commits land alongside the refactor commits:

- `816d653` — Plan's Task 1 fixture used non-existent `StateManager.record_run_start`/`record_run_complete`. Real API is `record_run()`. Plan patched after Task 1's implementer correctly worked around it.
- `683fce4` — Plan's Task 5/6 fixtures put table definitions inline in YAML, but `load_config()` reads tables from `discovery/curation.json`. Plan patched to use `write_curation()` + `make_curation_entry()` (matching the existing `tests/commands/conftest.py::cli_env` pattern).

These are honest plan-quality issues surfaced and fixed during execution — kept as separate commits for the audit trail.

## Commit list

```
16d739f fix(discover): preserve original prune-mode and rename-timestamp behavior (#43)
89d6171 refactor(discover): extract pure core into feather_etl.discover (#43)
4c5600d refactor(setup): extract pure core into feather_etl.setup (#43)
3c78578 docs(spec): test suite restructure design (issue #40)         ← unrelated, see below
683fce4 docs(plan): align Task 5 + Task 6 fixtures with curation-based config (#43)
35f64d3 refactor(validate): extract pure core into feather_etl.validate (#43)
66afa35 test(core): assert pure-core modules do not import typer (#43)
1d4df47 refactor(status): extract pure core into feather_etl.status (#43)
816d653 docs(plan): fix StateManager API in test fixtures (#43)
c8a122e refactor(history): extract pure core into feather_etl.history (#43)
b8ae72f docs(plan): thin-CLI refactor implementation plan (#43)
095222d docs(spec): thin-CLI refactor — split commands/<name>.py into thin wrapper + pure core (#43)
```

**Recommend:** merge with all commits preserved (no squash). Each task is atomic, individually revertable, and the per-task commit messages tell the story. Task 4 (`init` verify) is intentionally absent — verification surfaced no changes; documented in this PR description.

## Unrelated commit

`3c78578 docs(spec): test suite restructure design (issue #40)` is a separate spec for issue #40. Docs-only, harmless to ship together. Will be referenced by the eventual #40 PR.

## Out of scope

Per the spec's "Out of Scope" list (and confirmed during this work):

- **`scripts/hands_on_test.sh` is pre-existing broken on `main`.** Verified by checking out `main` and running the script — it fails at S2 with a curation-related error introduced upstream. The script is byte-identical between `main` and this branch (0 lines diff). This is **issue #40 territory** ("retire `hands_on_test.sh` in favor of pytest-only coverage"), explicitly out of scope per #43.
- Adding features or new CLI flags
- Changing the CLI surface — every `--flag` and output stays identical
- Touching `pipeline.py`, `cache.py`, `_common.py`, `state.py`, `config.py`, `init_wizard.py`, `viewer_server.py`, or `output.py`
- Refactoring `cache.py` (already conformant)

## Known follow-ups (deferred)

Tracked here for visibility — none block this PR:

1. **Type annotation drift:** `history.py` returns `list[dict]`; `status.py` returns `list[dict[str, object]]`. Both work at runtime; the tighter annotation matches `StateManager`'s actual return signature. Pick one across all read-through cores.
2. **Direct prod-mode test for `setup.run_setup`:** The `if cfg.mode == "prod":` branch in `setup.py` is currently covered transitively by `tests/test_transforms.py:815` and `tests/test_mode.py:315`, but no test exercises it through the `run_setup()` entry point. Add `test_run_setup_in_prod_mode_runs_gold_only` if a future setup change risks the prod-mode guard.
3. **Duplicate `_make_state_with_runs` test fixture** between `tests/test_history_core.py` and `tests/test_status_core.py`. Same 23 lines in both. Promote to `tests/conftest.py` if a third reader-core lands.
4. **Direct unit tests for two Task 7 spec items** not strictly required (covered at CLI/state level): `test_run_discover_with_retry_failed_only_retries_failed` and `test_run_discover_handles_pre_set_last_error_from_expand_db_sources`.

## Verification

```
$ uv run pytest -q
688 passed, 16 skipped in 26.93s

$ uv run pytest tests/test_core_module_purity.py -v
10 passed in 0.10s

$ for f in discover setup validate status history; do
    grep -q typer "src/feather_etl/$f.py" && echo "$f: HAS TYPER" || echo "$f: pure"
  done
discover: pure
setup: pure
validate: pure
status: pure
history: pure
```
