### PR TITLE
test: auto-bootstrap feather_test DB at pytest session start (closes #48)

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -163,6 +163,31 @@ tests belong with the code they exercise.
 
 ---
 
+## Local DB prerequisites
+
+Two DB-gated test groups run against your local machine's brew-managed
+servers:
+
+- **PostgreSQL** — 5 integration tests in `tests/unit/sources/test_postgres.py`
+  and `tests/e2e/test_03_discover.py`.
+- **MySQL** — integration tests in `tests/unit/sources/test_mysql.py`.
+
+Both expect a `feather_test` database to exist. The test suite creates
+it automatically at session start if the servers are up:
+
+```bash
+brew services start postgresql@17 mysql
+uv run pytest -q     # 0 DB-gated skips on a healthy setup
+```
+
+If a server is down, the suite prints a banner naming the exact
+`brew services start …` command, the gated tests skip with a clear
+reason, and the run still exits 0. Nothing else is needed — no manual
+`createdb`, no `.env` secrets. Localhost auth uses brew defaults
+(Postgres peer/trust, MySQL `root` without password).
+
+---
+
 ## Current open reviews
 
 | File | Slice | Status |

--- a/docs/superpowers/plans/2026-04-21-db-bootstrap-for-tests.md
+++ b/docs/superpowers/plans/2026-04-21-db-bootstrap-for-tests.md
@@ -1,0 +1,1200 @@
+# DB Bootstrap for Tests — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+Created: 2026-04-21
+Status: DRAFT
+Spec: [docs/superpowers/specs/2026-04-21-db-bootstrap-for-tests-design.md](../specs/2026-04-21-db-bootstrap-for-tests-design.md)
+Issue: [#48](https://github.com/siraj-samsudeen/feather-etl/issues/48)
+
+**Goal:** Auto-create `feather_test` on local Postgres & MySQL at pytest session start so DB-gated tests stop silently skipping.
+
+**Architecture:** New `tests/db_bootstrap.py` owns DSN constants, probes, per-flavor bootstrap, marker factories, and banner text. `tests/conftest.py` calls `ensure_bootstrap_databases()` from `pytest_sessionstart` (replacing the stale `pg_ctl` hook). The three test files that currently define local `_*_available()` probes import from the shared module instead.
+
+**Tech Stack:** pytest, psycopg2-binary, mysql-connector-python (all already in `pyproject.toml`).
+
+---
+
+## File Structure
+
+**Create**
+
+- `tests/db_bootstrap.py` — DSN constants, `postgres_check()`, `mysql_check()`, `_ensure_postgres_database()`, `_ensure_mysql_database()`, `ensure_bootstrap_databases()`, `format_banner()`, `postgres_marker()`, `mysql_marker()`.
+- `tests/unit/test_db_bootstrap.py` — unit tests (mocked drivers).
+- `tests/integration/test_db_bootstrap.py` — real-DB integration tests (use throwaway DB name, not `feather_test`).
+
+**Modify**
+
+- `tests/conftest.py:13-22` — replace `pytest_configure`/`pytest_unconfigure` pg_ctl hooks with `pytest_sessionstart` bootstrap trigger.
+- `tests/unit/sources/test_postgres.py:11-27` — delete local `CONN_STR` / `_postgres_available` / `postgres` marker; import from shared module.
+- `tests/e2e/test_03_discover.py:28-46` — same migration (also uses `CONN_STR` in `TestDiscoverPostgresMultiDatabase` helpers — re-point those).
+- `tests/unit/sources/test_mysql.py:161-175` — delete local `MYSQL_CONN_KWARGS` / `_mysql_available` / `mysql_db` marker; import from shared module.
+- `docs/CONTRIBUTING.md` — insert "Local DB prerequisites" section before "Dev shortcuts" (~line 164).
+
+**Outside scope**
+
+- `src/feather_etl/**`, `pyproject.toml`, any CI config.
+
+---
+
+## Design notes carried from spec
+
+- **Auth:** libpq default resolution (`PGUSER → USER`, no password) on Postgres; `user="root"`, no password on MySQL. Brew defaults on localhost make this work with no secret.
+- **Admin DSN:** `dbname=postgres host=localhost` for Postgres; on MySQL, omit `database=` from connect kwargs.
+- **Hook:** `pytest_sessionstart` (not `pytest_configure`) — bootstrapping a database is session lifecycle, not configuration.
+- **Marker factories:** markers are built by *factory functions* (`postgres_marker()`, `mysql_marker()`) called from test files at their import time — which happens after `pytest_sessionstart` has run bootstrap. Returning a fresh `pytest.mark.skipif(...)` on each call keeps the reason string live.
+- **`CREATE DATABASE` quirk:** Postgres requires `autocommit=True` on the admin connection.
+
+---
+
+## Task Breakdown
+
+### Task 1: DSN constants + probes (TDD)
+
+**Files:**
+- Create: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing probe tests**
+
+```python
+# tests/unit/test_db_bootstrap.py
+"""Unit tests for tests/db_bootstrap.py — drivers are always mocked here."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPostgresCheck:
+    def test_reachable_returns_true_none(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", lambda *a, **k: FakeConn())
+        ok, reason = dbb.postgres_check()
+        assert ok is True
+        assert reason is None
+
+    def test_unreachable_returns_false_with_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(*a, **k):
+            raise dbb.psycopg2.OperationalError("connection refused")
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", boom)
+        ok, reason = dbb.postgres_check()
+        assert ok is False
+        assert "connection refused" in reason
+
+
+class TestMySQLCheck:
+    def test_reachable_returns_true_none(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            dbb.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        ok, reason = dbb.mysql_check()
+        assert ok is True
+        assert reason is None
+
+    def test_unreachable_returns_false_with_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(**k):
+            raise dbb.mysql.connector.Error("access denied")
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", boom)
+        ok, reason = dbb.mysql_check()
+        assert ok is False
+        assert "access denied" in reason
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tests.db_bootstrap'`
+
+- [ ] **Step 3: Create `tests/db_bootstrap.py` with constants + probes**
+
+```python
+# tests/db_bootstrap.py
+"""Shared DB bootstrap for the test suite.
+
+Owns the DSN constants, live-reachability probes, the per-flavor
+`CREATE DATABASE IF NOT EXISTS` bootstrap, marker factories used by
+test files, and the session-start banner shown when a server is down.
+
+Everything here assumes brew-managed Postgres + MySQL on localhost with
+default trust/peer auth. Not designed for credentialed production DBs.
+"""
+
+from __future__ import annotations
+
+import mysql.connector
+import psycopg2
+import pytest
+
+# ---------------------------------------------------------------------------
+# Connection constants
+# ---------------------------------------------------------------------------
+
+TARGET_DB = "feather_test"
+
+POSTGRES_DSN = f"dbname={TARGET_DB} host=localhost"
+POSTGRES_ADMIN_DSN = "dbname=postgres host=localhost"
+
+MYSQL_CONN_KWARGS = {"host": "localhost", "user": "root", "database": TARGET_DB}
+MYSQL_ADMIN_KWARGS = {"host": "localhost", "user": "root"}
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def postgres_check() -> tuple[bool, str | None]:
+    """Return (True, None) if `feather_test` is reachable on Postgres."""
+    try:
+        conn = psycopg2.connect(POSTGRES_DSN)
+        conn.close()
+        return (True, None)
+    except Exception as exc:
+        return (False, str(exc))
+
+
+def mysql_check() -> tuple[bool, str | None]:
+    """Return (True, None) if `feather_test` is reachable on MySQL."""
+    try:
+        conn = mysql.connector.connect(**MYSQL_CONN_KWARGS)
+        conn.close()
+        return (True, None)
+    except Exception as exc:
+        return (False, str(exc))
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add DSN constants and live-reachability probes"
+```
+
+---
+
+### Task 2: Postgres bootstrap (TDD)
+
+**Files:**
+- Modify: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing Postgres-bootstrap tests**
+
+Append to `tests/unit/test_db_bootstrap.py`:
+
+```python
+class TestEnsurePostgresDatabase:
+    def _install_admin_connect(self, monkeypatch, exists: bool):
+        """Patch psycopg2.connect for the admin DSN. Returns lists of SQL
+        statements executed + whether a post-check probe was issued."""
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                # Only called for the "does it exist?" SELECT
+                return (1,) if exists else None
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            autocommit = False
+
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        def fake_connect(dsn, *a, **k):
+            # Only admin DSN is exercised here; the post-check uses
+            # postgres_check() which is monkeypatched separately.
+            assert dsn == dbb.POSTGRES_ADMIN_DSN
+            return FakeConn()
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", fake_connect)
+        return executed
+
+    def test_db_exists_no_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=True)
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is True
+        assert reason is None
+        # No CREATE should have been issued.
+        assert not any("CREATE DATABASE" in s for s in executed)
+
+    def test_db_missing_issues_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=False)
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is True
+        assert reason is None
+        assert any(
+            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
+        )
+
+    def test_driver_error_is_captured_not_raised(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(*a, **k):
+            raise dbb.psycopg2.OperationalError("server down")
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", boom)
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is False
+        assert "server down" in reason
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsurePostgresDatabase -v`
+Expected: FAIL with `AttributeError: module 'tests.db_bootstrap' has no attribute '_ensure_postgres_database'`
+
+- [ ] **Step 3: Add `_ensure_postgres_database` to `tests/db_bootstrap.py`**
+
+Append to `tests/db_bootstrap.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Per-flavor bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _ensure_postgres_database() -> tuple[bool, str | None]:
+    """Create `feather_test` on Postgres if it doesn't exist.
+
+    CREATE DATABASE cannot run inside a transaction, hence autocommit=True.
+    Any driver error is captured as the failure reason — never re-raised.
+    """
+    try:
+        admin = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        admin.autocommit = True
+        cur = admin.cursor()
+        try:
+            cur.execute(
+                "SELECT 1 FROM pg_database WHERE datname = %s", (TARGET_DB,)
+            )
+            if cur.fetchone() is None:
+                # Identifier cannot be parameterized; TARGET_DB is a fixed const.
+                cur.execute(f'CREATE DATABASE "{TARGET_DB}"')
+        finally:
+            cur.close()
+            admin.close()
+    except Exception as exc:
+        return (False, str(exc))
+
+    return postgres_check()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsurePostgresDatabase -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add Postgres CREATE DATABASE IF NOT EXISTS"
+```
+
+---
+
+### Task 3: MySQL bootstrap (TDD)
+
+**Files:**
+- Modify: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing MySQL-bootstrap tests**
+
+Append to `tests/unit/test_db_bootstrap.py`:
+
+```python
+class TestEnsureMySQLDatabase:
+    def _install_admin_connect(self, monkeypatch, exists: bool):
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                return (dbb.TARGET_DB,) if exists else None
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        def fake_connect(**kwargs):
+            assert "database" not in kwargs, (
+                "admin connect must NOT specify a database"
+            )
+            return FakeConn()
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", fake_connect)
+        return executed
+
+    def test_db_exists_no_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=True)
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is True
+        assert reason is None
+        assert not any("CREATE DATABASE" in s for s in executed)
+
+    def test_db_missing_issues_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=False)
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is True
+        assert reason is None
+        assert any(
+            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
+        )
+
+    def test_driver_error_is_captured_not_raised(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(**k):
+            raise dbb.mysql.connector.Error("connection refused")
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", boom)
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is False
+        assert "connection refused" in reason
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsureMySQLDatabase -v`
+Expected: FAIL with `AttributeError: ... '_ensure_mysql_database'`
+
+- [ ] **Step 3: Add `_ensure_mysql_database` to `tests/db_bootstrap.py`**
+
+Append to `tests/db_bootstrap.py`:
+
+```python
+def _ensure_mysql_database() -> tuple[bool, str | None]:
+    """Create `feather_test` on MySQL if it doesn't exist.
+
+    Connects with no `database=` kwarg to avoid the chicken-and-egg of
+    asking for a DB that may not yet exist. Any driver error is captured
+    as the failure reason — never re-raised.
+    """
+    try:
+        admin = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = admin.cursor()
+        try:
+            cur.execute(
+                "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+                "WHERE SCHEMA_NAME = %s",
+                (TARGET_DB,),
+            )
+            if cur.fetchone() is None:
+                cur.execute(f"CREATE DATABASE `{TARGET_DB}`")
+        finally:
+            cur.close()
+            admin.close()
+    except Exception as exc:
+        return (False, str(exc))
+
+    return mysql_check()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsureMySQLDatabase -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add MySQL CREATE DATABASE IF NOT EXISTS"
+```
+
+---
+
+### Task 4: Combined entry point + idempotency (TDD)
+
+**Files:**
+- Modify: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_db_bootstrap.py`:
+
+```python
+class TestEnsureBootstrapDatabases:
+    def test_returns_dict_with_both_flavors(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "_ensure_postgres_database", lambda: (True, None))
+        monkeypatch.setattr(dbb, "_ensure_mysql_database", lambda: (True, None))
+
+        results = dbb.ensure_bootstrap_databases()
+
+        assert set(results.keys()) == {"postgres", "mysql"}
+        assert results["postgres"] == (True, None)
+        assert results["mysql"] == (True, None)
+
+    def test_failure_reasons_are_propagated(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(
+            dbb, "_ensure_postgres_database", lambda: (False, "pg down")
+        )
+        monkeypatch.setattr(
+            dbb, "_ensure_mysql_database", lambda: (False, "my down")
+        )
+
+        results = dbb.ensure_bootstrap_databases()
+
+        assert results["postgres"] == (False, "pg down")
+        assert results["mysql"] == (False, "my down")
+
+    def test_idempotent_second_call_issues_no_create(self, monkeypatch):
+        """Two back-to-back calls on a DB that already exists → zero
+        CREATE statements on the second call (the existence check
+        short-circuits). This locks the spec's idempotency requirement."""
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                return (1,)  # always "exists"
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            autocommit = False
+
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", lambda *a, **k: FakeConn())
+        monkeypatch.setattr(
+            dbb.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        dbb.ensure_bootstrap_databases()
+        dbb.ensure_bootstrap_databases()
+
+        creates = [s for s in executed if "CREATE DATABASE" in s]
+        assert creates == []
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsureBootstrapDatabases -v`
+Expected: FAIL with `AttributeError: ... 'ensure_bootstrap_databases'`
+
+- [ ] **Step 3: Add `ensure_bootstrap_databases`**
+
+Append to `tests/db_bootstrap.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Combined session-start entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_bootstrap_databases() -> dict[str, tuple[bool, str | None]]:
+    """Run both flavor bootstraps. Returns per-flavor (ok, reason).
+
+    Called once from `pytest_sessionstart`. Per-flavor logic is
+    idempotent: exists → no CREATE; missing → one CREATE.
+    """
+    return {
+        "postgres": _ensure_postgres_database(),
+        "mysql": _ensure_mysql_database(),
+    }
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestEnsureBootstrapDatabases -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add combined ensure_bootstrap_databases entry point"
+```
+
+---
+
+### Task 5: Banner text helper (TDD)
+
+**Files:**
+- Modify: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_db_bootstrap.py`:
+
+```python
+class TestFormatBanner:
+    def test_both_ok_returns_none(self):
+        from tests.db_bootstrap import format_banner
+
+        assert format_banner({
+            "postgres": (True, None),
+            "mysql": (True, None),
+        }) is None
+
+    def test_postgres_down_names_brew_command(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (False, "could not connect"),
+            "mysql": (True, None),
+        })
+        assert out is not None
+        assert "brew services start postgresql@17" in out
+        assert "could not connect" in out
+
+    def test_mysql_down_names_brew_command(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (True, None),
+            "mysql": (False, "access denied"),
+        })
+        assert out is not None
+        assert "brew services start mysql" in out
+        assert "access denied" in out
+
+    def test_both_down_names_both(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (False, "pg"),
+            "mysql": (False, "my"),
+        })
+        assert "brew services start postgresql@17" in out
+        assert "brew services start mysql" in out
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestFormatBanner -v`
+Expected: FAIL with `ImportError: cannot import name 'format_banner'`
+
+- [ ] **Step 3: Add `format_banner`**
+
+Append to `tests/db_bootstrap.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Banner shown at session start when a server is down
+# ---------------------------------------------------------------------------
+
+
+_BREW_COMMANDS = {
+    "postgres": "brew services start postgresql@17",
+    "mysql": "brew services start mysql",
+}
+
+
+def format_banner(results: dict[str, tuple[bool, str | None]]) -> str | None:
+    """Return the session-start banner text, or None if both flavors are OK."""
+    failed = [(flavor, reason) for flavor, (ok, reason) in results.items() if not ok]
+    if not failed:
+        return None
+
+    lines = ["", "=" * 72, "feather-etl test suite: local DB unavailable"]
+    for flavor, reason in failed:
+        lines.append(f"  {flavor}: {reason}")
+        lines.append(f"    fix:  {_BREW_COMMANDS[flavor]}")
+    lines.append("DB-gated tests will skip. Suite will still exit 0.")
+    lines.append("=" * 72)
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestFormatBanner -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add session-start banner with brew-service hints"
+```
+
+---
+
+### Task 6: Marker factories (TDD)
+
+**Files:**
+- Modify: `tests/db_bootstrap.py`
+- Test: `tests/unit/test_db_bootstrap.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/unit/test_db_bootstrap.py`:
+
+```python
+class TestMarkerFactories:
+    """Markers are factories (not module-level constants) because conftest
+    imports this module BEFORE pytest_sessionstart runs bootstrap — if
+    the skipif boolean were evaluated at module load, it would see the
+    pre-bootstrap state."""
+
+    def test_postgres_marker_when_available(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+        marker = dbb.postgres_marker()
+
+        # A non-skipping skipif has condition=False
+        assert marker.kwargs.get("condition") is False or marker.args[0] is False
+
+    def test_postgres_marker_when_unavailable_uses_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (False, "pg down"))
+        marker = dbb.postgres_marker()
+
+        # condition=True → skip; reason comes from probe
+        cond = marker.kwargs.get("condition", marker.args[0] if marker.args else None)
+        assert cond is True
+        assert "pg down" in marker.kwargs["reason"]
+
+    def test_mysql_marker_when_unavailable_uses_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (False, "my down"))
+        marker = dbb.mysql_marker()
+
+        cond = marker.kwargs.get("condition", marker.args[0] if marker.args else None)
+        assert cond is True
+        assert "my down" in marker.kwargs["reason"]
+```
+
+- [ ] **Step 2: Run to verify fail**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestMarkerFactories -v`
+Expected: FAIL with `AttributeError: ... 'postgres_marker'`
+
+- [ ] **Step 3: Add marker factories**
+
+Append to `tests/db_bootstrap.py`:
+
+```python
+# ---------------------------------------------------------------------------
+# Marker factories
+# ---------------------------------------------------------------------------
+
+
+def postgres_marker():
+    """Build a fresh `pytest.mark.skipif` from a live probe.
+
+    Called at test-file import time — which is *after* pytest_sessionstart
+    has run bootstrap, so the probe sees the live DB.
+    """
+    ok, reason = postgres_check()
+    return pytest.mark.skipif(
+        not ok, reason=reason or "PostgreSQL not available"
+    )
+
+
+def mysql_marker():
+    ok, reason = mysql_check()
+    return pytest.mark.skipif(
+        not ok, reason=reason or "MySQL not available"
+    )
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py::TestMarkerFactories -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Full module test run**
+
+Run: `uv run pytest tests/unit/test_db_bootstrap.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/db_bootstrap.py tests/unit/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add postgres_marker/mysql_marker factories"
+```
+
+---
+
+### Task 7: Wire bootstrap into conftest via `pytest_sessionstart`
+
+**Files:**
+- Modify: `tests/conftest.py:1-23`
+
+- [ ] **Step 1: Replace the stale pg_ctl hooks**
+
+Replace lines 1-23 of `tests/conftest.py` with:
+
+```python
+"""Shared test fixtures for feather-etl."""
+
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.db_bootstrap import ensure_bootstrap_databases, format_banner
+from tests.helpers import make_curation_entry, write_curation
+
+
+def pytest_sessionstart(session):
+    """Create `feather_test` on local Postgres & MySQL if missing.
+
+    Runs before test collection, so `@postgres` / `@mysql_db` skipif
+    probes in test modules see the live DBs.
+
+    If a server is down, emit a banner naming the exact `brew services`
+    command to fix it. Never fail the session — the gated tests skip
+    with a clear reason and the suite still exits 0.
+    """
+    results = ensure_bootstrap_databases()
+    banner = format_banner(results)
+    if banner:
+        # stderr keeps the banner out of captured stdout that tests assert on
+        print(banner, file=sys.stderr)
+```
+
+- [ ] **Step 2: Run full suite, confirm fixtures still work**
+
+Run: `uv run pytest -q`
+Expected: suite runs. If both DBs are up, **0 skips** with reason "PostgreSQL not available" or "MySQL not available". If a DB is down, banner appears and gated tests skip cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/conftest.py
+git commit -m "test(db-bootstrap): trigger ensure_bootstrap_databases at session start"
+```
+
+---
+
+### Task 8: Migrate `tests/unit/sources/test_postgres.py`
+
+**Files:**
+- Modify: `tests/unit/sources/test_postgres.py:11-27`
+
+- [ ] **Step 1: Delete the local probe + marker block (lines 11-27)**
+
+Remove these lines from `tests/unit/sources/test_postgres.py`:
+
+```python
+CONN_STR = "dbname=feather_test host=localhost"
+
+
+def _postgres_available() -> bool:
+    try:
+        import psycopg2
+
+        conn = psycopg2.connect(CONN_STR)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+postgres = pytest.mark.skipif(
+    not _postgres_available(), reason="PostgreSQL not available"
+)
+```
+
+Replace with:
+
+```python
+from tests.db_bootstrap import POSTGRES_DSN as CONN_STR, postgres_marker
+
+postgres = postgres_marker()
+```
+
+(Keep `CONN_STR` as the local alias — the rest of the file uses it on many lines; aliasing avoids a churny rename.)
+
+- [ ] **Step 2: Run the file**
+
+Run: `uv run pytest tests/unit/sources/test_postgres.py -v`
+Expected: all previously-passing tests still PASS. No skips (assuming Postgres is up).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/sources/test_postgres.py
+git commit -m "test(db-bootstrap): migrate test_postgres.py to shared probe/marker"
+```
+
+---
+
+### Task 9: Migrate `tests/e2e/test_03_discover.py`
+
+**Files:**
+- Modify: `tests/e2e/test_03_discover.py:28-46`
+
+- [ ] **Step 1: Replace the probe + marker block**
+
+Remove lines 31-46 (`CONN_STR`, `_postgres_available`, `postgres` marker) and replace with:
+
+```python
+from tests.db_bootstrap import POSTGRES_DSN as CONN_STR, postgres_marker
+
+postgres = postgres_marker()
+```
+
+The existing `from tests.conftest import FIXTURES_DIR` import at line 28 stays.
+
+- [ ] **Step 2: Run the file**
+
+Run: `uv run pytest tests/e2e/test_03_discover.py -v`
+Expected: all previously-passing tests still PASS. `TestDiscoverPostgresMultiDatabase` runs (no skip) if Postgres is up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/test_03_discover.py
+git commit -m "test(db-bootstrap): migrate test_03_discover.py to shared probe/marker"
+```
+
+---
+
+### Task 10: Migrate `tests/unit/sources/test_mysql.py`
+
+**Files:**
+- Modify: `tests/unit/sources/test_mysql.py:161-175`
+
+- [ ] **Step 1: Replace the probe + marker block**
+
+Remove lines 161-175 (the `MYSQL_CONN_KWARGS` constant, `_mysql_available` function, and `mysql_db` marker) and replace with:
+
+```python
+from tests.db_bootstrap import MYSQL_CONN_KWARGS, mysql_marker
+
+mysql_db = mysql_marker()
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `uv run pytest tests/unit/sources/test_mysql.py -v`
+Expected: all previously-passing tests still PASS. MySQL integration tests run (no skip) if MySQL is up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/sources/test_mysql.py
+git commit -m "test(db-bootstrap): migrate test_mysql.py to shared probe/marker"
+```
+
+---
+
+### Task 11: Integration tests — real DB bootstrap
+
+**Files:**
+- Create: `tests/integration/test_db_bootstrap.py`
+
+These tests prove the bootstrap actually creates a DB against real servers. They use a **throwaway DB name** (`feather_bootstrap_it`) so they don't interfere with the live `feather_test` the rest of the suite depends on.
+
+- [ ] **Step 1: Write the integration tests**
+
+```python
+# tests/integration/test_db_bootstrap.py
+"""Real-DB integration tests for tests/db_bootstrap.py.
+
+Uses a throwaway DB name so we never touch `feather_test`.
+Each test: drop the DB → run bootstrap (pointed at the throwaway name)
+→ assert the DB now exists → drop it again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.db_bootstrap import (
+    MYSQL_ADMIN_KWARGS,
+    POSTGRES_ADMIN_DSN,
+    mysql_marker,
+    postgres_marker,
+)
+
+THROWAWAY_DB = "feather_bootstrap_it"
+
+
+@postgres_marker()
+class TestPostgresBootstrapIntegration:
+    def _drop(self):
+        import psycopg2
+
+        conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        conn.autocommit = True
+        cur = conn.cursor()
+        cur.execute(f'DROP DATABASE IF EXISTS "{THROWAWAY_DB}"')
+        cur.close()
+        conn.close()
+
+    def _exists(self) -> bool:
+        import psycopg2
+
+        conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT 1 FROM pg_database WHERE datname = %s", (THROWAWAY_DB,)
+        )
+        found = cur.fetchone() is not None
+        cur.close()
+        conn.close()
+        return found
+
+    def test_bootstrap_creates_missing_database(self, monkeypatch):
+        """Point the Postgres bootstrap at THROWAWAY_DB, drop it, run, assert."""
+        from tests import db_bootstrap as dbb
+
+        self._drop()
+        assert not self._exists()
+
+        monkeypatch.setattr(dbb, "TARGET_DB", THROWAWAY_DB)
+        monkeypatch.setattr(
+            dbb, "POSTGRES_DSN", f"dbname={THROWAWAY_DB} host=localhost"
+        )
+        try:
+            ok, reason = dbb._ensure_postgres_database()
+            assert ok, reason
+            assert self._exists()
+        finally:
+            self._drop()
+
+
+@mysql_marker()
+class TestMySQLBootstrapIntegration:
+    def _drop(self):
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = conn.cursor()
+        cur.execute(f"DROP DATABASE IF EXISTS `{THROWAWAY_DB}`")
+        cur.close()
+        conn.close()
+
+    def _exists(self) -> bool:
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+            "WHERE SCHEMA_NAME = %s",
+            (THROWAWAY_DB,),
+        )
+        found = cur.fetchone() is not None
+        cur.close()
+        conn.close()
+        return found
+
+    def test_bootstrap_creates_missing_database(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        self._drop()
+        assert not self._exists()
+
+        monkeypatch.setattr(dbb, "TARGET_DB", THROWAWAY_DB)
+        monkeypatch.setattr(
+            dbb,
+            "MYSQL_CONN_KWARGS",
+            {"host": "localhost", "user": "root", "database": THROWAWAY_DB},
+        )
+        try:
+            ok, reason = dbb._ensure_mysql_database()
+            assert ok, reason
+            assert self._exists()
+        finally:
+            self._drop()
+```
+
+- [ ] **Step 2: Run the file**
+
+Run: `uv run pytest tests/integration/test_db_bootstrap.py -v`
+Expected: 2 PASS (if both DBs up); otherwise the unavailable flavor skips cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/test_db_bootstrap.py
+git commit -m "test(db-bootstrap): add real-DB integration tests via throwaway DB"
+```
+
+---
+
+### Task 12: Docs — Local DB prerequisites
+
+**Files:**
+- Modify: `docs/CONTRIBUTING.md` (insert before `## Dev shortcuts` at ~line 164)
+
+- [ ] **Step 1: Insert the section**
+
+Insert this block immediately before the `## Dev shortcuts (\`poe\`)` heading:
+
+```markdown
+## Local DB prerequisites
+
+Two DB-gated test groups run against your local machine's brew-managed
+servers:
+
+- **PostgreSQL** — 5 integration tests in `tests/unit/sources/test_postgres.py`
+  and `tests/e2e/test_03_discover.py`.
+- **MySQL** — integration tests in `tests/unit/sources/test_mysql.py`.
+
+Both expect a `feather_test` database to exist. The test suite creates
+it automatically at session start if the servers are up:
+
+```bash
+brew services start postgresql@17 mysql
+uv run pytest -q     # 0 DB-gated skips on a healthy setup
+```
+
+If a server is down, the suite prints a banner naming the exact
+`brew services start …` command, the gated tests skip with a clear
+reason, and the run still exits 0. Nothing else is needed — no manual
+`createdb`, no `.env` secrets. Localhost auth uses brew defaults
+(Postgres peer/trust, MySQL `root` without password).
+
+---
+```
+
+- [ ] **Step 2: Verify in an editor / markdown viewer**
+
+Just read the section back to make sure it slots in cleanly between the preceding "Do not create feature-named test files" paragraph and the `## Dev shortcuts` heading.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/CONTRIBUTING.md
+git commit -m "docs(contributing): add Local DB prerequisites section"
+```
+
+---
+
+### Task 13: End-to-end verification (no commit)
+
+This is the spec's acceptance-criteria exemplar (§3), run by hand.
+
+- [ ] **Step 1: Baseline — both servers up**
+
+Run:
+```bash
+brew services start postgresql@17 mysql
+uv run pytest -q
+```
+Expected: suite completes, **zero** skips with reason "PostgreSQL not available" or "MySQL not available".
+
+Quick check:
+```bash
+uv run pytest -q 2>&1 | grep -E "(PostgreSQL|MySQL) not available" | wc -l
+```
+Expected: `0`.
+
+- [ ] **Step 2: Postgres down**
+
+Run:
+```bash
+brew services stop postgresql@17
+uv run pytest -q
+```
+Expected: banner on stderr naming `brew services start postgresql@17`, 5 postgres-gated tests skip, exit code 0.
+
+- [ ] **Step 3: Restore**
+
+Run:
+```bash
+brew services start postgresql@17
+uv run pytest -q
+```
+Expected: back to zero DB-gated skips.
+
+- [ ] **Step 4: Report**
+
+If all three steps pass, the implementation meets the spec's acceptance criteria. No commit — this is verification only.
+
+---
+
+## Self-review
+
+- **Spec coverage:** every spec §3 acceptance criterion maps to Task 13 steps. Spec §4 Scope items: auto-create DB (Tasks 2–4), banner (Task 5), probe consolidation (Tasks 8–10), stale `pg_ctl` removal (Task 7), CONTRIBUTING section (Task 12). Spec §8 Test design: probe tests (Task 1), exists/missing/driver-error for each flavor (Tasks 2–3), idempotency (Task 4), integration (Task 11).
+- **Placeholders:** none — every code step shows the actual code.
+- **Type consistency:** `postgres_check()`, `mysql_check()`, `_ensure_*_database()`, and `ensure_bootstrap_databases()` all return `(bool, str | None)` / `dict[str, tuple[bool, str | None]]` — consistent across tasks and callers.

--- a/src/feather_etl/commands/cache.py
+++ b/src/feather_etl/commands/cache.py
@@ -93,6 +93,7 @@ def cache(
 
     # Grouped-by-source_db output
     from collections import defaultdict
+
     groups: dict[str, list] = defaultdict(list)
     for r in results:
         groups[r.source_db].append(r)
@@ -143,6 +144,7 @@ def cache(
 def _lookup_source_name(cfg, source_db: str) -> str:
     """Find the YAML source 'name' corresponding to a source_db."""
     from feather_etl.curation import resolve_source
+
     try:
         src = resolve_source(source_db, cfg.sources)
         return src.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,25 +1,31 @@
 """Shared test fixtures for feather-etl."""
 
 import shutil
-import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
+from tests.db_bootstrap import ensure_bootstrap_databases, format_banner
 from tests.helpers import make_curation_entry, write_curation
 
 
-def pytest_configure(config):
-    """Start PostgreSQL before test collection (so skipif checks see it)."""
-    if shutil.which("pg_ctl"):
-        subprocess.run(["pg_ctl", "start", "-l", "/dev/null"], capture_output=True)
+def pytest_sessionstart(session):
+    """Create `feather_test` on local Postgres & MySQL if missing.
 
+    Runs before test collection, so `@postgres` / `@mysql_db` skipif
+    probes in test modules see the live DBs.
 
-def pytest_unconfigure(config):
-    """Stop PostgreSQL after the test session."""
-    if shutil.which("pg_ctl"):
-        subprocess.run(["pg_ctl", "stop"], capture_output=True)
+    If a server is down, emit a banner naming the exact `brew services`
+    command to fix it. Never fail the session — the gated tests skip
+    with a clear reason and the suite still exits 0.
+    """
+    results = ensure_bootstrap_databases()
+    banner = format_banner(results)
+    if banner:
+        # stderr keeps the banner out of captured stdout that tests assert on
+        print(banner, file=sys.stderr)
 
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 import mysql.connector
 import psycopg2
-import pytest
 
 # ---------------------------------------------------------------------------
 # Connection constants

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import mysql.connector
 import psycopg2
+import pytest
 
 # ---------------------------------------------------------------------------
 # Connection constants
@@ -148,3 +149,27 @@ def format_banner(results: dict[str, tuple[bool, str | None]]) -> str | None:
     lines.append("DB-gated tests will skip. Suite will still exit 0.")
     lines.append("=" * 72)
     return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Marker factories
+# ---------------------------------------------------------------------------
+
+
+def postgres_marker():
+    """Build a fresh `pytest.mark.skipif` from a live probe.
+
+    Called at test-file import time — which is *after* pytest_sessionstart
+    has run bootstrap, so the probe sees the live DB.
+    """
+    ok, reason = postgres_check()
+    return pytest.mark.skipif(
+        not ok, reason=reason or "PostgreSQL not available"
+    )
+
+
+def mysql_marker():
+    ok, reason = mysql_check()
+    return pytest.mark.skipif(
+        not ok, reason=reason or "MySQL not available"
+    )

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -122,3 +122,29 @@ def ensure_bootstrap_databases() -> dict[str, tuple[bool, str | None]]:
         "postgres": _ensure_postgres_database(),
         "mysql": _ensure_mysql_database(),
     }
+
+
+# ---------------------------------------------------------------------------
+# Banner shown at session start when a server is down
+# ---------------------------------------------------------------------------
+
+
+_BREW_COMMANDS = {
+    "postgres": "brew services start postgresql@17",
+    "mysql": "brew services start mysql",
+}
+
+
+def format_banner(results: dict[str, tuple[bool, str | None]]) -> str | None:
+    """Return the session-start banner text, or None if both flavors are OK."""
+    failed = [(flavor, reason) for flavor, (ok, reason) in results.items() if not ok]
+    if not failed:
+        return None
+
+    lines = ["", "=" * 72, "feather-etl test suite: local DB unavailable"]
+    for flavor, reason in failed:
+        lines.append(f"  {flavor}: {reason}")
+        lines.append(f"    fix:  {_BREW_COMMANDS[flavor]}")
+    lines.append("DB-gated tests will skip. Suite will still exit 0.")
+    lines.append("=" * 72)
+    return "\n".join(lines)

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -1,0 +1,52 @@
+"""Shared DB bootstrap for the test suite.
+
+Owns the DSN constants, live-reachability probes, the per-flavor
+`CREATE DATABASE IF NOT EXISTS` bootstrap, marker factories used by
+test files, and the session-start banner shown when a server is down.
+
+Everything here assumes brew-managed Postgres + MySQL on localhost with
+default trust/peer auth. Not designed for credentialed production DBs.
+"""
+
+from __future__ import annotations
+
+import mysql.connector
+import psycopg2
+import pytest
+
+# ---------------------------------------------------------------------------
+# Connection constants
+# ---------------------------------------------------------------------------
+
+TARGET_DB = "feather_test"
+
+POSTGRES_DSN = f"dbname={TARGET_DB} host=localhost"
+POSTGRES_ADMIN_DSN = "dbname=postgres host=localhost"
+
+MYSQL_CONN_KWARGS = {"host": "localhost", "user": "root", "database": TARGET_DB}
+MYSQL_ADMIN_KWARGS = {"host": "localhost", "user": "root"}
+
+
+# ---------------------------------------------------------------------------
+# Probes
+# ---------------------------------------------------------------------------
+
+
+def postgres_check() -> tuple[bool, str | None]:
+    """Return (True, None) if `feather_test` is reachable on Postgres."""
+    try:
+        conn = psycopg2.connect(POSTGRES_DSN)
+        conn.close()
+        return (True, None)
+    except Exception as exc:
+        return (False, str(exc))
+
+
+def mysql_check() -> tuple[bool, str | None]:
+    """Return (True, None) if `feather_test` is reachable on MySQL."""
+    try:
+        conn = mysql.connector.connect(**MYSQL_CONN_KWARGS)
+        conn.close()
+        return (True, None)
+    except Exception as exc:
+        return (False, str(exc))

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -49,3 +49,34 @@ def mysql_check() -> tuple[bool, str | None]:
         return (True, None)
     except Exception as exc:
         return (False, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Per-flavor bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _ensure_postgres_database() -> tuple[bool, str | None]:
+    """Create `feather_test` on Postgres if it doesn't exist.
+
+    CREATE DATABASE cannot run inside a transaction, hence autocommit=True.
+    Any driver error is captured as the failure reason — never re-raised.
+    """
+    try:
+        admin = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        admin.autocommit = True
+        cur = admin.cursor()
+        try:
+            cur.execute(
+                "SELECT 1 FROM pg_database WHERE datname = %s", (TARGET_DB,)
+            )
+            if cur.fetchone() is None:
+                # Identifier cannot be parameterized; TARGET_DB is a fixed const.
+                cur.execute(f'CREATE DATABASE "{TARGET_DB}"')
+        finally:
+            cur.close()
+            admin.close()
+    except Exception as exc:
+        return (False, str(exc))
+
+    return postgres_check()

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -80,3 +80,30 @@ def _ensure_postgres_database() -> tuple[bool, str | None]:
         return (False, str(exc))
 
     return postgres_check()
+
+
+def _ensure_mysql_database() -> tuple[bool, str | None]:
+    """Create `feather_test` on MySQL if it doesn't exist.
+
+    Connects with no `database=` kwarg to avoid the chicken-and-egg of
+    asking for a DB that may not yet exist. Any driver error is captured
+    as the failure reason — never re-raised.
+    """
+    try:
+        admin = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = admin.cursor()
+        try:
+            cur.execute(
+                "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+                "WHERE SCHEMA_NAME = %s",
+                (TARGET_DB,),
+            )
+            if cur.fetchone() is None:
+                cur.execute(f"CREATE DATABASE `{TARGET_DB}`")
+        finally:
+            cur.close()
+            admin.close()
+    except Exception as exc:
+        return (False, str(exc))
+
+    return mysql_check()

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -67,9 +67,7 @@ def _ensure_postgres_database() -> tuple[bool, str | None]:
         admin.autocommit = True
         cur = admin.cursor()
         try:
-            cur.execute(
-                "SELECT 1 FROM pg_database WHERE datname = %s", (TARGET_DB,)
-            )
+            cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (TARGET_DB,))
             if cur.fetchone() is None:
                 # Identifier cannot be parameterized; TARGET_DB is a fixed const.
                 cur.execute(f'CREATE DATABASE "{TARGET_DB}"')
@@ -107,3 +105,20 @@ def _ensure_mysql_database() -> tuple[bool, str | None]:
         return (False, str(exc))
 
     return mysql_check()
+
+
+# ---------------------------------------------------------------------------
+# Combined session-start entry point
+# ---------------------------------------------------------------------------
+
+
+def ensure_bootstrap_databases() -> dict[str, tuple[bool, str | None]]:
+    """Run both flavor bootstraps. Returns per-flavor (ok, reason).
+
+    Called once from `pytest_sessionstart`. Per-flavor logic is
+    idempotent: exists → no CREATE; missing → one CREATE.
+    """
+    return {
+        "postgres": _ensure_postgres_database(),
+        "mysql": _ensure_mysql_database(),
+    }

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -163,13 +163,9 @@ def postgres_marker():
     has run bootstrap, so the probe sees the live DB.
     """
     ok, reason = postgres_check()
-    return pytest.mark.skipif(
-        not ok, reason=reason or "PostgreSQL not available"
-    )
+    return pytest.mark.skipif(not ok, reason=reason or "PostgreSQL not available")
 
 
 def mysql_marker():
     ok, reason = mysql_check()
-    return pytest.mark.skipif(
-        not ok, reason=reason or "MySQL not available"
-    )
+    return pytest.mark.skipif(not ok, reason=reason or "MySQL not available")

--- a/tests/db_bootstrap.py
+++ b/tests/db_bootstrap.py
@@ -167,5 +167,10 @@ def postgres_marker():
 
 
 def mysql_marker():
+    """Build a fresh `pytest.mark.skipif` from a live probe.
+
+    Called at test-file import time — which is *after* pytest_sessionstart
+    has run bootstrap, so the probe sees the live DB.
+    """
     ok, reason = mysql_check()
     return pytest.mark.skipif(not ok, reason=reason or "MySQL not available")

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -71,7 +71,9 @@ class ProjectFixture:
         `tests.helpers.make_curation_entry` directly and then
         `tests.helpers.write_curation` yourself.
         """
-        tables = [make_curation_entry(src, table, alias) for (src, table, alias) in entries]
+        tables = [
+            make_curation_entry(src, table, alias) for (src, table, alias) in entries
+        ]
         return write_curation(self.root, tables)
 
     def copy_fixture(self, name: str) -> Path:
@@ -145,4 +147,5 @@ def stub_viewer_serve(monkeypatch):
     the function becomes a no-op.
     """
     import feather_etl.commands.discover as discover_cmd
+
     monkeypatch.setattr(discover_cmd, "serve_and_open", lambda *a, **kw: None)

--- a/tests/e2e/test_03_discover.py
+++ b/tests/e2e/test_03_discover.py
@@ -28,22 +28,9 @@ import yaml
 from tests.conftest import FIXTURES_DIR
 
 
-CONN_STR = "dbname=feather_test host=localhost"
+from tests.db_bootstrap import POSTGRES_DSN as CONN_STR, postgres_marker
 
-
-def _postgres_available() -> bool:
-    try:
-        import psycopg2
-
-        psycopg2.connect(CONN_STR).close()
-        return True
-    except Exception:
-        return False
-
-
-postgres = pytest.mark.skipif(
-    not _postgres_available(), reason="PostgreSQL not available"
-)
+postgres = postgres_marker()
 
 
 # ---------------------------------------------------------------------------
@@ -791,9 +778,7 @@ def _write_rename_configs(project) -> tuple[Path, Path]:
         yaml.dump(
             {
                 "sources": [{"name": "erp", "type": "sqlite", "path": str(sqlite)}],
-                "destination": {
-                    "path": str(project.root / "feather_data.duckdb")
-                },
+                "destination": {"path": str(project.root / "feather_data.duckdb")},
             },
             default_flow_style=False,
         )
@@ -805,9 +790,7 @@ def _write_rename_configs(project) -> tuple[Path, Path]:
                 "sources": [
                     {"name": "erp_main", "type": "sqlite", "path": str(sqlite)}
                 ],
-                "destination": {
-                    "path": str(project.root / "feather_data.duckdb")
-                },
+                "destination": {"path": str(project.root / "feather_data.duckdb")},
             },
             default_flow_style=False,
         )
@@ -817,9 +800,7 @@ def _write_rename_configs(project) -> tuple[Path, Path]:
 
 @pytest.mark.usefixtures("stub_viewer_serve")
 class TestRenameNonTtyExit3:
-    def test_rename_in_yaml_first_invocation_exits_3(
-        self, project, cli, monkeypatch
-    ):
+    def test_rename_in_yaml_first_invocation_exits_3(self, project, cli, monkeypatch):
         first_cfg, renamed_cfg = _write_rename_configs(project)
         monkeypatch.chdir(project.root)
 
@@ -847,9 +828,7 @@ class TestRenameNonTtyExit3:
         assert (project.root / "schema_sqlite_erp_main.json").is_file()
         assert not (project.root / "schema_sqlite_erp.json").exists()
 
-        state = json.loads(
-            (project.root / "feather_discover_state.json").read_text()
-        )
+        state = json.loads((project.root / "feather_discover_state.json").read_text())
         assert "erp_main" in state["sources"]
         assert "erp" not in state["sources"]
 
@@ -863,15 +842,11 @@ class TestRenameNonTtyExit3:
         second = cli("discover", "--no-renames", config=renamed_cfg)
         assert second.exit_code == 0, second.output
 
-        state = json.loads(
-            (project.root / "feather_discover_state.json").read_text()
-        )
+        state = json.loads((project.root / "feather_discover_state.json").read_text())
         assert state["sources"]["erp"]["status"] == "orphaned"
         assert state["sources"]["erp_main"]["status"] == "ok"
 
-    def test_refresh_flag_bypasses_rename_confirmation(
-        self, project, cli, monkeypatch
-    ):
+    def test_refresh_flag_bypasses_rename_confirmation(self, project, cli, monkeypatch):
         first_cfg, renamed_cfg = _write_rename_configs(project)
         monkeypatch.chdir(project.root)
 
@@ -883,15 +858,11 @@ class TestRenameNonTtyExit3:
         assert "Rename confirmation required" not in refreshed.output
         assert (project.root / "schema_sqlite_erp_main.json").is_file()
 
-        state = json.loads(
-            (project.root / "feather_discover_state.json").read_text()
-        )
+        state = json.loads((project.root / "feather_discover_state.json").read_text())
         assert state["sources"]["erp_main"]["status"] == "ok"
         assert state["sources"]["erp"]["status"] == "removed"
 
-    def test_prune_flag_bypasses_rename_confirmation(
-        self, project, cli, monkeypatch
-    ):
+    def test_prune_flag_bypasses_rename_confirmation(self, project, cli, monkeypatch):
         first_cfg, renamed_cfg = _write_rename_configs(project)
         monkeypatch.chdir(project.root)
 
@@ -905,9 +876,7 @@ class TestRenameNonTtyExit3:
         assert not (project.root / "schema_sqlite_erp.json").exists()
         assert not (project.root / "schema_sqlite_erp_main.json").exists()
 
-        state = json.loads(
-            (project.root / "feather_discover_state.json").read_text()
-        )
+        state = json.loads((project.root / "feather_discover_state.json").read_text())
         assert "erp" not in state["sources"]
 
 

--- a/tests/e2e/test_04_extract_full.py
+++ b/tests/e2e/test_04_extract_full.py
@@ -316,7 +316,5 @@ def test_cli_mode_flag_via_runner(project, cli):
     result = cli("run", "--mode", "prod")
     assert result.exit_code == 0
 
-    silver_count = project.query(
-        "SELECT COUNT(*) FROM silver.erp_customers"
-    )[0][0]
+    silver_count = project.query("SELECT COUNT(*) FROM silver.erp_customers")[0][0]
     assert silver_count > 0

--- a/tests/e2e/test_07_transforms.py
+++ b/tests/e2e/test_07_transforms.py
@@ -93,8 +93,7 @@ def test_setup_reports_gold_views_in_dev_mode(project, cli):
         project.root,
         "gold",
         "emp_summary",
-        "-- depends_on: silver.emp_clean\n"
-        "SELECT COUNT(*) AS n FROM silver.emp_clean",
+        "-- depends_on: silver.emp_clean\nSELECT COUNT(*) AS n FROM silver.emp_clean",
     )
 
     result = cli("setup")

--- a/tests/e2e/test_12_cache.py
+++ b/tests/e2e/test_12_cache.py
@@ -107,8 +107,7 @@ def test_table_filter_restricts_extraction(project, cli):
     assert result.exit_code == 0
 
     rows = project.query(
-        "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'bronze'"
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
     )
     tables = {r[0] for r in rows}
     assert "icube_inv" in tables
@@ -122,8 +121,7 @@ def test_source_filter_restricts_extraction(project, cli):
     assert result.exit_code == 0
 
     rows = project.query(
-        "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'bronze'"
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
     )
     tables = {r[0] for r in rows}
     assert "icube_inv" in tables
@@ -136,8 +134,7 @@ def test_table_and_source_intersect(project, cli):
     assert result.exit_code == 0
 
     rows = project.query(
-        "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'bronze'"
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
     )
     tables = {r[0] for r in rows}
     assert tables == {"icube_inv"}

--- a/tests/e2e/test_13_multi_source.py
+++ b/tests/e2e/test_13_multi_source.py
@@ -31,8 +31,16 @@ def _write_two_fixture_sources(project) -> None:
     shutil.copy2(project.root / "client.duckdb", project.root / "client_b.duckdb")
     project.write_config(
         sources=[
-            {"name": "a", "type": "duckdb", "path": str(project.root / "client.duckdb")},
-            {"name": "b", "type": "duckdb", "path": str(project.root / "client_b.duckdb")},
+            {
+                "name": "a",
+                "type": "duckdb",
+                "path": str(project.root / "client.duckdb"),
+            },
+            {
+                "name": "b",
+                "type": "duckdb",
+                "path": str(project.root / "client_b.duckdb"),
+            },
         ],
         destination={"path": str(project.root / "out.duckdb")},
     )
@@ -164,8 +172,7 @@ def test_feather_run_extracts_from_multiple_sources(project, cli, monkeypatch):
 
     # Verify data landed in bronze.
     rows = project.query(
-        "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'bronze'"
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
     )
     tables = [r[0] for r in rows]
 
@@ -199,8 +206,7 @@ def test_table_filter_works_with_bronze_name(project, cli, monkeypatch):
     assert result.exit_code == 0
 
     rows = project.query(
-        "SELECT table_name FROM information_schema.tables "
-        "WHERE table_schema = 'bronze'"
+        "SELECT table_name FROM information_schema.tables WHERE table_schema = 'bronze'"
     )
     tables = [r[0] for r in rows]
 

--- a/tests/e2e/test_14_status.py
+++ b/tests/e2e/test_14_status.py
@@ -14,7 +14,13 @@ from tests.helpers import make_curation_entry, write_curation
 def test_shows_status_after_run(cli, project):
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])
@@ -28,7 +34,13 @@ def test_shows_status_after_run(cli, project):
 def test_status_no_state_db(cli, project):
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])
@@ -41,7 +53,13 @@ def test_status_no_state_db(cli, project):
 def test_status_no_runs_yet(cli, project):
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])
@@ -57,7 +75,13 @@ def test_status_json_empty_rows_is_silent(cli, project):
     (early-returns) rather than emitting a 'No runs recorded' sentinel."""
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])
@@ -73,7 +97,13 @@ def test_status_shows_error_message_for_failures(cli, project):
     """UX-5: feather status should display error text for failed tables."""
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     write_curation(
@@ -94,7 +124,13 @@ def test_status_shows_all_time_history(cli, project):
 
     # First config: inventory_group
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     write_curation(
@@ -124,7 +160,13 @@ def test_status_json_outputs_ndjson(cli, project):
     """AC-FR11.d: feather status --json outputs NDJSON with required fields."""
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])

--- a/tests/e2e/test_15_history.py
+++ b/tests/e2e/test_15_history.py
@@ -12,7 +12,13 @@ import json
 def _two_table_env(project):
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation(
@@ -117,7 +123,13 @@ def test_history_shows_error_row_and_truncates_long_messages(cli, project):
 def test_history_json_outputs_ndjson(cli, project):
     project.copy_fixture("client.duckdb")
     project.write_config(
-        sources=[{"type": "duckdb", "name": "icube", "path": str(project.root / "client.duckdb")}],
+        sources=[
+            {
+                "type": "duckdb",
+                "name": "icube",
+                "path": str(project.root / "client.duckdb"),
+            }
+        ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
     project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])

--- a/tests/e2e/test_16_view.py
+++ b/tests/e2e/test_16_view.py
@@ -16,7 +16,9 @@ def _forbid_sync(*args, **kwargs):
     raise AssertionError("view should not call sync_viewer_html directly")
 
 
-def test_uses_current_directory_by_default(cli, project, monkeypatch: pytest.MonkeyPatch):
+def test_uses_current_directory_by_default(
+    cli, project, monkeypatch: pytest.MonkeyPatch
+):
     from feather_etl import viewer_server
 
     seen: dict[str, object] = {}

--- a/tests/e2e/test_fixture_smoke.py
+++ b/tests/e2e/test_fixture_smoke.py
@@ -29,6 +29,7 @@ def test_write_config_persists_yaml(project):
     assert project.config_path.exists()
     # The file parses back to a dict we recognise.
     import yaml
+
     parsed = yaml.safe_load(project.config_path.read_text())
     assert parsed["sources"][0]["name"] == "s"
     assert parsed["destination"]["path"] == "./feather_data.duckdb"
@@ -39,6 +40,7 @@ def test_write_curation_creates_discovery_json(project):
     curation_path = project.root / "discovery" / "curation.json"
     assert curation_path.exists()
     import json
+
     manifest = json.loads(curation_path.read_text())
     assert manifest["tables"][0]["alias"] == "orders"
     assert manifest["tables"][0]["source_db"] == "s"
@@ -61,6 +63,7 @@ def test_copy_fixture_directory_copies_recursively(project):
 def test_query_returns_rows_from_data_db(project):
     # Seed the data DB directly so we can exercise .query without running a pipeline.
     import duckdb
+
     with duckdb.connect(str(project.data_db_path)) as con:
         con.execute("CREATE TABLE t (x INT)")
         con.execute("INSERT INTO t VALUES (1), (2), (3)")
@@ -106,7 +109,9 @@ def test_cli_with_explicit_config_path_uses_it(project, cli, tmp_path_factory):
     # Write a valid config to project.root with a name we can grep.
     project.copy_fixture("sample_erp.sqlite")
     project.write_config(
-        sources=[{"type": "sqlite", "name": "marker_one", "path": "./sample_erp.sqlite"}],
+        sources=[
+            {"type": "sqlite", "name": "marker_one", "path": "./sample_erp.sqlite"}
+        ],
         destination={"path": "./feather_data.duckdb"},
     )
     project.write_curation([("marker_one", "orders", "orders")])
@@ -114,21 +119,39 @@ def test_cli_with_explicit_config_path_uses_it(project, cli, tmp_path_factory):
     # Write a SECOND config file with a different source name; pass it explicitly.
     other_cfg = project.root / "feather_other.yaml"
     import yaml
-    other_cfg.write_text(yaml.dump({
-        "sources": [{"type": "sqlite", "name": "marker_two",
-                     "path": "./sample_erp.sqlite"}],
-        "destination": {"path": "./feather_data_other.duckdb"},
-    }, default_flow_style=False))
+
+    other_cfg.write_text(
+        yaml.dump(
+            {
+                "sources": [
+                    {
+                        "type": "sqlite",
+                        "name": "marker_two",
+                        "path": "./sample_erp.sqlite",
+                    }
+                ],
+                "destination": {"path": "./feather_data_other.duckdb"},
+            },
+            default_flow_style=False,
+        )
+    )
     # Reuse the same curation but under a different source name.
     from tests.helpers import make_curation_entry, write_curation
+
     # Rewrite curation to reference marker_two so validate passes.
-    write_curation(project.root, [make_curation_entry("marker_two", "orders", "orders")])
+    write_curation(
+        project.root, [make_curation_entry("marker_two", "orders", "orders")]
+    )
 
     result = cli("validate", config=other_cfg)
     assert result.exit_code == 0, result.output
     # The source-count summary will mention the other config's data.
     # Just assert it didn't quietly use the default.
-    assert "marker_two" in result.output or "1 source" in result.output or "1 table" in result.output
+    assert (
+        "marker_two" in result.output
+        or "1 source" in result.output
+        or "1 table" in result.output
+    )
 
 
 def test_stub_viewer_serve_prevents_browser_open(project, cli, monkeypatch):
@@ -138,6 +161,7 @@ def test_stub_viewer_serve_prevents_browser_open(project, cli, monkeypatch):
     This smoke test doesn't apply the fixture but shows the target attribute
     exists and is overridable."""
     import feather_etl.commands.discover as discover_cmd
+
     assert hasattr(discover_cmd, "serve_and_open"), (
         "discover command still exposes serve_and_open — stub_viewer_serve fixture relies on this"
     )

--- a/tests/integration/test_append.py
+++ b/tests/integration/test_append.py
@@ -87,9 +87,7 @@ def test_append_second_run_appends_on_change(tmp_path: Path):
     assert all(r.status == "success" for r in results2)
 
     dest_con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
-    count = dest_con.execute(
-        "SELECT COUNT(*) FROM bronze.src_customers"
-    ).fetchone()[0]
+    count = dest_con.execute("SELECT COUNT(*) FROM bronze.src_customers").fetchone()[0]
     dest_con.close()
     assert count == 9
 
@@ -110,8 +108,6 @@ def test_append_unchanged_source_skips(tmp_path: Path):
     assert all(r.status == "skipped" for r in results2)
 
     dest_con = duckdb.connect(str(tmp_path / "feather_data.duckdb"), read_only=True)
-    count = dest_con.execute(
-        "SELECT COUNT(*) FROM bronze.src_customers"
-    ).fetchone()[0]
+    count = dest_con.execute("SELECT COUNT(*) FROM bronze.src_customers").fetchone()[0]
     dest_con.close()
     assert count == 4

--- a/tests/integration/test_cache_pipeline.py
+++ b/tests/integration/test_cache_pipeline.py
@@ -27,9 +27,7 @@ def _setup_project(project):
         ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
-    project.write_curation(
-        [("icube", "icube.InventoryGroup", "inventory_group")]
-    )
+    project.write_curation([("icube", "icube.InventoryGroup", "inventory_group")])
 
 
 def test_extracts_all_columns_into_bronze(project):
@@ -63,9 +61,7 @@ def test_extracts_all_columns_into_bronze(project):
         "GRPNAME",
         "Alias",
     }
-    assert required.issubset(cols), (
-        f"Missing expected columns. Got: {sorted(cols)}"
-    )
+    assert required.issubset(cols), f"Missing expected columns. Got: {sorted(cols)}"
 
 
 def test_writes_only_to_cache_watermarks(project):
@@ -153,9 +149,7 @@ def test_unresolvable_source_db_records_failure_without_raising(project):
         ],
         destination={"path": str(project.root / "feather_data.duckdb")},
     )
-    entry = make_curation_entry(
-        "icube", "icube.InventoryGroup", "orphan_table"
-    )
+    entry = make_curation_entry("icube", "icube.InventoryGroup", "orphan_table")
     # Override database to a name that doesn't exist anywhere in cfg.sources
     entry["source_db"] = "nonexistent_system"
     write_curation(project.root, [entry])

--- a/tests/integration/test_db_bootstrap.py
+++ b/tests/integration/test_db_bootstrap.py
@@ -23,22 +23,32 @@ class TestPostgresBootstrapIntegration:
         import psycopg2
 
         conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
-        conn.autocommit = True
-        cur = conn.cursor()
-        cur.execute(f'DROP DATABASE IF EXISTS "{THROWAWAY_DB}"')
-        cur.close()
-        conn.close()
+        try:
+            conn.autocommit = True
+            cur = conn.cursor()
+            try:
+                cur.execute(f'DROP DATABASE IF EXISTS "{THROWAWAY_DB}"')
+            finally:
+                cur.close()
+        finally:
+            conn.close()
 
     def _exists(self) -> bool:
         import psycopg2
 
         conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
-        cur = conn.cursor()
-        cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (THROWAWAY_DB,))
-        found = cur.fetchone() is not None
-        cur.close()
-        conn.close()
-        return found
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    "SELECT 1 FROM pg_database WHERE datname = %s",
+                    (THROWAWAY_DB,),
+                )
+                return cur.fetchone() is not None
+            finally:
+                cur.close()
+        finally:
+            conn.close()
 
     def test_bootstrap_creates_missing_database(self, monkeypatch):
         """Point the Postgres bootstrap at THROWAWAY_DB, drop it, run, assert."""
@@ -65,25 +75,32 @@ class TestMySQLBootstrapIntegration:
         import mysql.connector
 
         conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
-        cur = conn.cursor()
-        cur.execute(f"DROP DATABASE IF EXISTS `{THROWAWAY_DB}`")
-        cur.close()
-        conn.close()
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute(f"DROP DATABASE IF EXISTS `{THROWAWAY_DB}`")
+            finally:
+                cur.close()
+        finally:
+            conn.close()
 
     def _exists(self) -> bool:
         import mysql.connector
 
         conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
-        cur = conn.cursor()
-        cur.execute(
-            "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
-            "WHERE SCHEMA_NAME = %s",
-            (THROWAWAY_DB,),
-        )
-        found = cur.fetchone() is not None
-        cur.close()
-        conn.close()
-        return found
+        try:
+            cur = conn.cursor()
+            try:
+                cur.execute(
+                    "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+                    "WHERE SCHEMA_NAME = %s",
+                    (THROWAWAY_DB,),
+                )
+                return cur.fetchone() is not None
+            finally:
+                cur.close()
+        finally:
+            conn.close()
 
     def test_bootstrap_creates_missing_database(self, monkeypatch):
         from tests import db_bootstrap as dbb

--- a/tests/integration/test_db_bootstrap.py
+++ b/tests/integration/test_db_bootstrap.py
@@ -34,9 +34,7 @@ class TestPostgresBootstrapIntegration:
 
         conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
         cur = conn.cursor()
-        cur.execute(
-            "SELECT 1 FROM pg_database WHERE datname = %s", (THROWAWAY_DB,)
-        )
+        cur.execute("SELECT 1 FROM pg_database WHERE datname = %s", (THROWAWAY_DB,))
         found = cur.fetchone() is not None
         cur.close()
         conn.close()

--- a/tests/integration/test_db_bootstrap.py
+++ b/tests/integration/test_db_bootstrap.py
@@ -1,0 +1,107 @@
+"""Real-DB integration tests for tests/db_bootstrap.py.
+
+Uses a throwaway DB name so we never touch `feather_test`.
+Each test: drop the DB → run bootstrap (pointed at the throwaway name)
+→ assert the DB now exists → drop it again.
+"""
+
+from __future__ import annotations
+
+from tests.db_bootstrap import (
+    MYSQL_ADMIN_KWARGS,
+    POSTGRES_ADMIN_DSN,
+    mysql_marker,
+    postgres_marker,
+)
+
+THROWAWAY_DB = "feather_bootstrap_it"
+
+
+@postgres_marker()
+class TestPostgresBootstrapIntegration:
+    def _drop(self):
+        import psycopg2
+
+        conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        conn.autocommit = True
+        cur = conn.cursor()
+        cur.execute(f'DROP DATABASE IF EXISTS "{THROWAWAY_DB}"')
+        cur.close()
+        conn.close()
+
+    def _exists(self) -> bool:
+        import psycopg2
+
+        conn = psycopg2.connect(POSTGRES_ADMIN_DSN)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT 1 FROM pg_database WHERE datname = %s", (THROWAWAY_DB,)
+        )
+        found = cur.fetchone() is not None
+        cur.close()
+        conn.close()
+        return found
+
+    def test_bootstrap_creates_missing_database(self, monkeypatch):
+        """Point the Postgres bootstrap at THROWAWAY_DB, drop it, run, assert."""
+        from tests import db_bootstrap as dbb
+
+        self._drop()
+        assert not self._exists()
+
+        monkeypatch.setattr(dbb, "TARGET_DB", THROWAWAY_DB)
+        monkeypatch.setattr(
+            dbb, "POSTGRES_DSN", f"dbname={THROWAWAY_DB} host=localhost"
+        )
+        try:
+            ok, reason = dbb._ensure_postgres_database()
+            assert ok, reason
+            assert self._exists()
+        finally:
+            self._drop()
+
+
+@mysql_marker()
+class TestMySQLBootstrapIntegration:
+    def _drop(self):
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = conn.cursor()
+        cur.execute(f"DROP DATABASE IF EXISTS `{THROWAWAY_DB}`")
+        cur.close()
+        conn.close()
+
+    def _exists(self) -> bool:
+        import mysql.connector
+
+        conn = mysql.connector.connect(**MYSQL_ADMIN_KWARGS)
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA "
+            "WHERE SCHEMA_NAME = %s",
+            (THROWAWAY_DB,),
+        )
+        found = cur.fetchone() is not None
+        cur.close()
+        conn.close()
+        return found
+
+    def test_bootstrap_creates_missing_database(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        self._drop()
+        assert not self._exists()
+
+        monkeypatch.setattr(dbb, "TARGET_DB", THROWAWAY_DB)
+        monkeypatch.setattr(
+            dbb,
+            "MYSQL_CONN_KWARGS",
+            {"host": "localhost", "user": "root", "database": THROWAWAY_DB},
+        )
+        try:
+            ok, reason = dbb._ensure_mysql_database()
+            assert ok, reason
+            assert self._exists()
+        finally:
+            self._drop()

--- a/tests/integration/test_discover.py
+++ b/tests/integration/test_discover.py
@@ -66,7 +66,9 @@ def test_detect_renames_returns_empty_proposals_when_state_is_empty(project):
 def test_detect_renames_finds_rename_when_fingerprint_matches_under_new_name(project):
     """Rename a source in YAML; same fingerprint → proposal."""
     # First load with name "old_db" — record state.
-    cfg = load_config(_setup_sqlite_project(project, source_name="old_db"), validate=False)
+    cfg = load_config(
+        _setup_sqlite_project(project, source_name="old_db"), validate=False
+    )
     state = DiscoverState.load(project.root)
     sources = expand_db_sources(cfg.sources)
     # Simulate a prior successful discover under "old_db".
@@ -79,7 +81,9 @@ def test_detect_renames_finds_rename_when_fingerprint_matches_under_new_name(pro
     )
 
     # Now rename source to "new_db".
-    cfg = load_config(_setup_sqlite_project(project, source_name="new_db"), validate=False)
+    cfg = load_config(
+        _setup_sqlite_project(project, source_name="new_db"), validate=False
+    )
     sources = expand_db_sources(cfg.sources)
 
     detection = detect_renames_for_sources(state, sources)
@@ -91,7 +95,9 @@ def test_detect_renames_finds_rename_when_fingerprint_matches_under_new_name(pro
 def test_detect_renames_returns_ambiguous_when_multiple_state_entries_match(project):
     """Two stale state entries with the same fingerprint as one current
     source → ambiguous (cannot decide which old name was renamed)."""
-    cfg = load_config(_setup_sqlite_project(project, source_name="new_db"), validate=False)
+    cfg = load_config(
+        _setup_sqlite_project(project, source_name="new_db"), validate=False
+    )
     state = DiscoverState.load(project.root)
     sources = expand_db_sources(cfg.sources)
     fp = _fingerprint_for(sources[0])
@@ -123,7 +129,9 @@ def test_detect_renames_returns_ambiguous_when_multiple_state_entries_match(proj
 
 
 def test_apply_rename_decision_renames_state_and_files_for_accepted_proposals(project):
-    cfg = load_config(_setup_sqlite_project(project, source_name="new_db"), validate=False)
+    cfg = load_config(
+        _setup_sqlite_project(project, source_name="new_db"), validate=False
+    )
     state = DiscoverState.load(project.root)
     sources = expand_db_sources(cfg.sources)
     fp = _fingerprint_for(sources[0])
@@ -150,7 +158,9 @@ def test_apply_rename_decision_renames_state_and_files_for_accepted_proposals(pr
 
 
 def test_apply_rename_decision_marks_orphaned_for_rejected_proposals(project):
-    cfg = load_config(_setup_sqlite_project(project, source_name="new_db"), validate=False)
+    cfg = load_config(
+        _setup_sqlite_project(project, source_name="new_db"), validate=False
+    )
     state = DiscoverState.load(project.root)
     sources = expand_db_sources(cfg.sources)
     fp = _fingerprint_for(sources[0])

--- a/tests/integration/test_incremental.py
+++ b/tests/integration/test_incremental.py
@@ -79,7 +79,10 @@ def _write_incremental_config(
 def test_first_incremental_run_extracts_all(project):
     src_path = _make_source_db(project.root)
     cfg = _write_incremental_config(
-        project, src_path, source_table="erp.orders", alias="orders",
+        project,
+        src_path,
+        source_table="erp.orders",
+        alias="orders",
         primary_key=["order_id"],
     )
 
@@ -98,7 +101,10 @@ def test_first_incremental_run_extracts_all(project):
 def test_second_run_no_new_rows_extracts_zero(project):
     src_path = _make_source_db(project.root)
     cfg = _write_incremental_config(
-        project, src_path, source_table="erp.orders", alias="orders",
+        project,
+        src_path,
+        source_table="erp.orders",
+        alias="orders",
         primary_key=["order_id"],
     )
 
@@ -110,7 +116,10 @@ def test_second_run_no_new_rows_extracts_zero(project):
 def test_incremental_after_new_rows(project):
     src_path = _make_source_db(project.root)
     cfg = _write_incremental_config(
-        project, src_path, source_table="erp.orders", alias="orders",
+        project,
+        src_path,
+        source_table="erp.orders",
+        alias="orders",
         primary_key=["order_id"],
     )
 
@@ -136,7 +145,10 @@ def test_incremental_after_new_rows(project):
 def test_run_after_incremental_no_new_rows_watermark_unchanged(project):
     src_path = _make_source_db(project.root)
     cfg = _write_incremental_config(
-        project, src_path, source_table="erp.orders", alias="orders",
+        project,
+        src_path,
+        source_table="erp.orders",
+        alias="orders",
         primary_key=["order_id"],
     )
 
@@ -178,8 +190,12 @@ def test_filter_excludes_matching_rows(project):
     con.close()
 
     cfg = _write_incremental_config(
-        project, src_path, source_table="erp.orders", alias="orders",
-        primary_key=["order_id"], filter="status <> 'cancelled'",
+        project,
+        src_path,
+        source_table="erp.orders",
+        alias="orders",
+        primary_key=["order_id"],
+        filter="status <> 'cancelled'",
     )
     result = run_table(cfg, cfg.tables[0], project.root)
 
@@ -199,7 +215,10 @@ def test_filter_excludes_matching_rows(project):
 
 def test_full_incremental_cycle_with_fixture(sample_erp_db, project):
     cfg = _write_incremental_config(
-        project, sample_erp_db, source_table="erp.sales", alias="sales",
+        project,
+        sample_erp_db,
+        source_table="erp.sales",
+        alias="sales",
         primary_key=["sale_id"],
     )
 
@@ -238,8 +257,12 @@ def test_full_incremental_cycle_with_fixture(sample_erp_db, project):
 
 def test_filter_with_fixture(sample_erp_db, project):
     cfg = _write_incremental_config(
-        project, sample_erp_db, source_table="erp.sales", alias="sales",
-        primary_key=["sale_id"], filter="status <> 'cancelled'",
+        project,
+        sample_erp_db,
+        source_table="erp.sales",
+        alias="sales",
+        primary_key=["sale_id"],
+        filter="status <> 'cancelled'",
     )
     result = run_table(cfg, cfg.tables[0], project.root)
 
@@ -301,8 +324,7 @@ def test_incremental_second_run_zero_new_rows_success_path(project):
     # overlap=0, the incremental extract then returns zero rows directly.
     con = duckdb.connect(str(src_path))
     con.execute(
-        "UPDATE erp.orders SET modified_at = '2025-01-04 12:00:00' "
-        "WHERE order_id = 5"
+        "UPDATE erp.orders SET modified_at = '2025-01-04 12:00:00' WHERE order_id = 5"
     )
     con.close()
 
@@ -405,10 +427,7 @@ def test_incremental_prod_mode_applies_column_map(project):
 
     # Second run with a new row → hits the is_incremental+wm branch
     con = duckdb.connect(str(src_path))
-    con.execute(
-        "INSERT INTO erp.orders VALUES "
-        "(6, 600.00, '2025-01-06 00:00:00')"
-    )
+    con.execute("INSERT INTO erp.orders VALUES (6, 600.00, '2025-01-06 00:00:00')")
     con.close()
 
     result = run_table(cfg, cfg.tables[0], project.root)
@@ -504,7 +523,10 @@ def test_append_prod_mode_applies_column_map(project):
 
 def test_overlap_window_arithmetic(sample_erp_db, project):
     cfg = _write_incremental_config(
-        project, sample_erp_db, source_table="erp.sales", alias="sales",
+        project,
+        sample_erp_db,
+        source_table="erp.sales",
+        alias="sales",
         primary_key=["sale_id"],
     )
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -300,9 +300,7 @@ class TestClientFixtureEdgeCases:
         con.close()
         assert "Round Off" in cols, "'Round Off' column (space) should be preserved"
 
-    def test_invitem_blob_columns(
-        self, project: ProjectFixture, client_db_copy: Path
-    ):
+    def test_invitem_blob_columns(self, project: ProjectFixture, client_db_copy: Path):
         """INVITEM has BLOB columns (IMAGE, DivImage).  Should load without error."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
@@ -317,9 +315,7 @@ class TestClientFixtureEdgeCases:
         assert results[0].status == "success"
         assert results[0].rows_loaded == 1058
 
-    def test_all_six_icube_tables(
-        self, project: ProjectFixture, client_db_copy: Path
-    ):
+    def test_all_six_icube_tables(self, project: ProjectFixture, client_db_copy: Path):
         """All six Icube tables load in a single run."""
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
@@ -463,9 +459,7 @@ class TestErrorIsolation:
 class TestValidationGuards:
     """Tests that validate catches invalid config before runtime."""
 
-    def test_csv_source_validates_with_valid_directory(
-        self, project: ProjectFixture
-    ):
+    def test_csv_source_validates_with_valid_directory(self, project: ProjectFixture):
         """CSV source type with a valid directory passes validation."""
         from feather_etl.config import load_config
 
@@ -521,9 +515,7 @@ class TestValidationGuards:
         with pytest.raises(ValueError, match="CSV source path must be a directory"):
             load_config(project.config_path)
 
-    def test_missing_source_section_raises_valueerror(
-        self, project: ProjectFixture
-    ):
+    def test_missing_source_section_raises_valueerror(self, project: ProjectFixture):
         from feather_etl.config import load_config
 
         # Bypass ``write_config``'s tolerant behaviour and write raw YAML with
@@ -571,9 +563,7 @@ class TestValidationGuards:
 
 
 class TestPipelineReturnsOnFailure:
-    def test_run_all_returns_results_on_total_failure(
-        self, project: ProjectFixture
-    ):
+    def test_run_all_returns_results_on_total_failure(self, project: ProjectFixture):
         from feather_etl.config import load_config
         from feather_etl.pipeline import run_all
 

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -1,5 +1,4 @@
-"""Integration: feather_etl.pipeline — run_table and run_all orchestration across sources, destinations, and state.
-"""
+"""Integration: feather_etl.pipeline — run_table and run_all orchestration across sources, destinations, and state."""
 
 from __future__ import annotations
 
@@ -153,8 +152,7 @@ def test_modified_source_reextracts(project):
     source_db = project.root / "client.duckdb"
     con = duckdb.connect(str(source_db))
     con.execute(
-        "INSERT INTO icube.InventoryGroup "
-        "SELECT * FROM icube.InventoryGroup LIMIT 1"
+        "INSERT INTO icube.InventoryGroup SELECT * FROM icube.InventoryGroup LIMIT 1"
     )
     con.close()
 

--- a/tests/integration/test_transforms.py
+++ b/tests/integration/test_transforms.py
@@ -156,9 +156,7 @@ def test_run_no_rebuild_when_all_skipped(tmp_path: Path):
         [make_curation_entry("src", "erp.employees", "employees")],
     )
 
-    _write_sql(
-        tmp_path, "gold", "emp_snap", ("-- materialized: true\nSELECT 1 AS val")
-    )
+    _write_sql(tmp_path, "gold", "emp_snap", ("-- materialized: true\nSELECT 1 AS val"))
 
     cfg = load_config(config_file)
 
@@ -202,7 +200,9 @@ def test_run_all_transform_rebuild_failure_is_caught_and_logged(
     )
 
     _write_sql(
-        tmp_path, "silver", "emp_clean",
+        tmp_path,
+        "silver",
+        "emp_clean",
         "SELECT * FROM bronze.src_employees",
     )
 

--- a/tests/unit/sources/test_expand.py
+++ b/tests/unit/sources/test_expand.py
@@ -105,7 +105,9 @@ def test_db_source_with_single_database_passes_through() -> None:
     assert result == [mock_src]
 
 
-def test_db_source_list_databases_raises_records_last_error_and_passes_through() -> None:
+def test_db_source_list_databases_raises_records_last_error_and_passes_through() -> (
+    None
+):
     """When ``list_databases()`` raises, the source is kept in the list with
     an informative ``_last_error`` so downstream discover can report it."""
     from feather_etl.sources.database_source import DatabaseSource

--- a/tests/unit/sources/test_mysql.py
+++ b/tests/unit/sources/test_mysql.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.db_bootstrap import MYSQL_CONN_KWARGS, mysql_marker
+
 
 # ---------------------------------------------------------------------------
 # MySQLSource.from_yaml — unit tests (no DB needed)
@@ -158,21 +160,7 @@ class TestMySQLValidateSourceTable:
 # ---------------------------------------------------------------------------
 
 
-MYSQL_CONN_KWARGS = {"host": "localhost", "user": "root", "database": "feather_test"}
-
-
-def _mysql_available() -> bool:
-    try:
-        import mysql.connector
-
-        conn = mysql.connector.connect(**MYSQL_CONN_KWARGS)
-        conn.close()
-        return True
-    except Exception:
-        return False
-
-
-mysql_db = pytest.mark.skipif(not _mysql_available(), reason="MySQL not available")
+mysql_db = mysql_marker()
 
 
 class TestMySQLCheckLastError:

--- a/tests/unit/sources/test_postgres.py
+++ b/tests/unit/sources/test_postgres.py
@@ -8,23 +8,9 @@ from __future__ import annotations
 
 import pytest
 
-CONN_STR = "dbname=feather_test host=localhost"
+from tests.db_bootstrap import POSTGRES_DSN as CONN_STR, postgres_marker
 
-
-def _postgres_available() -> bool:
-    try:
-        import psycopg2
-
-        conn = psycopg2.connect(CONN_STR)
-        conn.close()
-        return True
-    except Exception:
-        return False
-
-
-postgres = pytest.mark.skipif(
-    not _postgres_available(), reason="PostgreSQL not available"
-)
+postgres = postgres_marker()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -630,7 +630,9 @@ class TestSourcesList:
         }
         config_file = tmp_path / "feather.yaml"
         config_file.write_text(yaml.dump(cfg_dict))
-        with pytest.raises(ValueError, match=r"sources\[0\] missing required field 'type'"):
+        with pytest.raises(
+            ValueError, match=r"sources\[0\] missing required field 'type'"
+        ):
             load_config(config_file, validate=False)
 
 

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -264,3 +264,45 @@ class TestEnsureBootstrapDatabases:
 
         creates = [s for s in executed if "CREATE DATABASE" in s]
         assert creates == []
+
+
+class TestFormatBanner:
+    def test_both_ok_returns_none(self):
+        from tests.db_bootstrap import format_banner
+
+        assert format_banner({
+            "postgres": (True, None),
+            "mysql": (True, None),
+        }) is None
+
+    def test_postgres_down_names_brew_command(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (False, "could not connect"),
+            "mysql": (True, None),
+        })
+        assert out is not None
+        assert "brew services start postgresql@17" in out
+        assert "could not connect" in out
+
+    def test_mysql_down_names_brew_command(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (True, None),
+            "mysql": (False, "access denied"),
+        })
+        assert out is not None
+        assert "brew services start mysql" in out
+        assert "access denied" in out
+
+    def test_both_down_names_both(self):
+        from tests.db_bootstrap import format_banner
+
+        out = format_banner({
+            "postgres": (False, "pg"),
+            "mysql": (False, "my"),
+        })
+        assert "brew services start postgresql@17" in out
+        assert "brew services start mysql" in out

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -216,9 +216,7 @@ class TestEnsureBootstrapDatabases:
         monkeypatch.setattr(
             dbb, "_ensure_postgres_database", lambda: (False, "pg down")
         )
-        monkeypatch.setattr(
-            dbb, "_ensure_mysql_database", lambda: (False, "my down")
-        )
+        monkeypatch.setattr(dbb, "_ensure_mysql_database", lambda: (False, "my down"))
 
         results = dbb.ensure_bootstrap_databases()
 
@@ -253,9 +251,7 @@ class TestEnsureBootstrapDatabases:
                 pass
 
         monkeypatch.setattr(dbb.psycopg2, "connect", lambda *a, **k: FakeConn())
-        monkeypatch.setattr(
-            dbb.mysql.connector, "connect", lambda **k: FakeConn()
-        )
+        monkeypatch.setattr(dbb.mysql.connector, "connect", lambda **k: FakeConn())
         monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
         monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
 
@@ -270,18 +266,25 @@ class TestFormatBanner:
     def test_both_ok_returns_none(self):
         from tests.db_bootstrap import format_banner
 
-        assert format_banner({
-            "postgres": (True, None),
-            "mysql": (True, None),
-        }) is None
+        assert (
+            format_banner(
+                {
+                    "postgres": (True, None),
+                    "mysql": (True, None),
+                }
+            )
+            is None
+        )
 
     def test_postgres_down_names_brew_command(self):
         from tests.db_bootstrap import format_banner
 
-        out = format_banner({
-            "postgres": (False, "could not connect"),
-            "mysql": (True, None),
-        })
+        out = format_banner(
+            {
+                "postgres": (False, "could not connect"),
+                "mysql": (True, None),
+            }
+        )
         assert out is not None
         assert "brew services start postgresql@17" in out
         assert "could not connect" in out
@@ -289,10 +292,12 @@ class TestFormatBanner:
     def test_mysql_down_names_brew_command(self):
         from tests.db_bootstrap import format_banner
 
-        out = format_banner({
-            "postgres": (True, None),
-            "mysql": (False, "access denied"),
-        })
+        out = format_banner(
+            {
+                "postgres": (True, None),
+                "mysql": (False, "access denied"),
+            }
+        )
         assert out is not None
         assert "brew services start mysql" in out
         assert "access denied" in out
@@ -300,10 +305,12 @@ class TestFormatBanner:
     def test_both_down_names_both(self):
         from tests.db_bootstrap import format_banner
 
-        out = format_banner({
-            "postgres": (False, "pg"),
-            "mysql": (False, "my"),
-        })
+        out = format_banner(
+            {
+                "postgres": (False, "pg"),
+                "mysql": (False, "my"),
+            }
+        )
         assert "brew services start postgresql@17" in out
         assert "brew services start mysql" in out
 

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -131,3 +131,75 @@ class TestEnsurePostgresDatabase:
 
         assert ok is False
         assert "server down" in reason
+
+
+class TestEnsureMySQLDatabase:
+    def _install_admin_connect(self, monkeypatch, exists: bool):
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                return (dbb.TARGET_DB,) if exists else None
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        def fake_connect(**kwargs):
+            assert "database" not in kwargs, (
+                "admin connect must NOT specify a database"
+            )
+            return FakeConn()
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", fake_connect)
+        return executed
+
+    def test_db_exists_no_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=True)
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is True
+        assert reason is None
+        assert not any("CREATE DATABASE" in s for s in executed)
+
+    def test_db_missing_issues_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=False)
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is True
+        assert reason is None
+        assert any(
+            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
+        )
+
+    def test_driver_error_is_captured_not_raised(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(**k):
+            raise dbb.mysql.connector.Error("connection refused")
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", boom)
+
+        ok, reason = dbb._ensure_mysql_database()
+
+        assert ok is False
+        assert "connection refused" in reason

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -57,8 +57,8 @@ class TestMySQLCheck:
 
 class TestEnsurePostgresDatabase:
     def _install_admin_connect(self, monkeypatch, exists: bool):
-        """Patch psycopg2.connect for the admin DSN. Returns lists of SQL
-        statements executed + whether a post-check probe was issued."""
+        """Patch psycopg2.connect for the admin DSN. Returns the list of
+        SQL statements the fake cursor observed."""
         from tests import db_bootstrap as dbb
 
         executed: list[str] = []

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -36,9 +36,7 @@ class TestMySQLCheck:
             def close(self):
                 pass
 
-        monkeypatch.setattr(
-            dbb.mysql.connector, "connect", lambda **k: FakeConn()
-        )
+        monkeypatch.setattr(dbb.mysql.connector, "connect", lambda **k: FakeConn())
         ok, reason = dbb.mysql_check()
         assert ok is True
         assert reason is None
@@ -115,9 +113,7 @@ class TestEnsurePostgresDatabase:
 
         assert ok is True
         assert reason is None
-        assert any(
-            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
-        )
+        assert any("CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed)
 
     def test_driver_error_is_captured_not_raised(self, monkeypatch):
         from tests import db_bootstrap as dbb
@@ -157,9 +153,7 @@ class TestEnsureMySQLDatabase:
                 pass
 
         def fake_connect(**kwargs):
-            assert "database" not in kwargs, (
-                "admin connect must NOT specify a database"
-            )
+            assert "database" not in kwargs, "admin connect must NOT specify a database"
             return FakeConn()
 
         monkeypatch.setattr(dbb.mysql.connector, "connect", fake_connect)
@@ -187,9 +181,7 @@ class TestEnsureMySQLDatabase:
 
         assert ok is True
         assert reason is None
-        assert any(
-            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
-        )
+        assert any("CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed)
 
     def test_driver_error_is_captured_not_raised(self, monkeypatch):
         from tests import db_bootstrap as dbb
@@ -203,3 +195,72 @@ class TestEnsureMySQLDatabase:
 
         assert ok is False
         assert "connection refused" in reason
+
+
+class TestEnsureBootstrapDatabases:
+    def test_returns_dict_with_both_flavors(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "_ensure_postgres_database", lambda: (True, None))
+        monkeypatch.setattr(dbb, "_ensure_mysql_database", lambda: (True, None))
+
+        results = dbb.ensure_bootstrap_databases()
+
+        assert set(results.keys()) == {"postgres", "mysql"}
+        assert results["postgres"] == (True, None)
+        assert results["mysql"] == (True, None)
+
+    def test_failure_reasons_are_propagated(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(
+            dbb, "_ensure_postgres_database", lambda: (False, "pg down")
+        )
+        monkeypatch.setattr(
+            dbb, "_ensure_mysql_database", lambda: (False, "my down")
+        )
+
+        results = dbb.ensure_bootstrap_databases()
+
+        assert results["postgres"] == (False, "pg down")
+        assert results["mysql"] == (False, "my down")
+
+    def test_idempotent_second_call_issues_no_create(self, monkeypatch):
+        """Two back-to-back calls on a DB that already exists → zero
+        CREATE statements on the second call (the existence check
+        short-circuits). This locks the spec's idempotency requirement."""
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                return (1,)  # always "exists"
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            autocommit = False
+
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", lambda *a, **k: FakeConn())
+        monkeypatch.setattr(
+            dbb.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (True, None))
+
+        dbb.ensure_bootstrap_databases()
+        dbb.ensure_bootstrap_databases()
+
+        creates = [s for s in executed if "CREATE DATABASE" in s]
+        assert creates == []

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -53,3 +53,81 @@ class TestMySQLCheck:
         ok, reason = dbb.mysql_check()
         assert ok is False
         assert "access denied" in reason
+
+
+class TestEnsurePostgresDatabase:
+    def _install_admin_connect(self, monkeypatch, exists: bool):
+        """Patch psycopg2.connect for the admin DSN. Returns lists of SQL
+        statements executed + whether a post-check probe was issued."""
+        from tests import db_bootstrap as dbb
+
+        executed: list[str] = []
+
+        class FakeCursor:
+            def execute(self, sql, *_):
+                executed.append(sql)
+
+            def fetchone(self):
+                # Only called for the "does it exist?" SELECT
+                return (1,) if exists else None
+
+            def close(self):
+                pass
+
+        class FakeConn:
+            autocommit = False
+
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        def fake_connect(dsn, *a, **k):
+            # Only admin DSN is exercised here; the post-check uses
+            # postgres_check() which is monkeypatched separately.
+            assert dsn == dbb.POSTGRES_ADMIN_DSN
+            return FakeConn()
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", fake_connect)
+        return executed
+
+    def test_db_exists_no_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=True)
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is True
+        assert reason is None
+        # No CREATE should have been issued.
+        assert not any("CREATE DATABASE" in s for s in executed)
+
+    def test_db_missing_issues_create(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        executed = self._install_admin_connect(monkeypatch, exists=False)
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is True
+        assert reason is None
+        assert any(
+            "CREATE DATABASE" in s and dbb.TARGET_DB in s for s in executed
+        )
+
+    def test_driver_error_is_captured_not_raised(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(*a, **k):
+            raise dbb.psycopg2.OperationalError("server down")
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", boom)
+
+        ok, reason = dbb._ensure_postgres_database()
+
+        assert ok is False
+        assert "server down" in reason

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -306,3 +306,40 @@ class TestFormatBanner:
         })
         assert "brew services start postgresql@17" in out
         assert "brew services start mysql" in out
+
+
+class TestMarkerFactories:
+    """Markers are factories (not module-level constants) because conftest
+    imports this module BEFORE pytest_sessionstart runs bootstrap — if
+    the skipif boolean were evaluated at module load, it would see the
+    pre-bootstrap state."""
+
+    def test_postgres_marker_when_available(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (True, None))
+        marker = dbb.postgres_marker()
+
+        # A non-skipping skipif has condition=False
+        assert marker.kwargs.get("condition") is False or marker.args[0] is False
+
+    def test_postgres_marker_when_unavailable_uses_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "postgres_check", lambda: (False, "pg down"))
+        marker = dbb.postgres_marker()
+
+        # condition=True → skip; reason comes from probe
+        cond = marker.kwargs.get("condition", marker.args[0] if marker.args else None)
+        assert cond is True
+        assert "pg down" in marker.kwargs["reason"]
+
+    def test_mysql_marker_when_unavailable_uses_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        monkeypatch.setattr(dbb, "mysql_check", lambda: (False, "my down"))
+        marker = dbb.mysql_marker()
+
+        cond = marker.kwargs.get("condition", marker.args[0] if marker.args else None)
+        assert cond is True
+        assert "my down" in marker.kwargs["reason"]

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 
 class TestPostgresCheck:
     def test_reachable_returns_true_none(self, monkeypatch):

--- a/tests/unit/test_db_bootstrap.py
+++ b/tests/unit/test_db_bootstrap.py
@@ -1,0 +1,57 @@
+"""Unit tests for tests/db_bootstrap.py — drivers are always mocked here."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPostgresCheck:
+    def test_reachable_returns_true_none(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", lambda *a, **k: FakeConn())
+        ok, reason = dbb.postgres_check()
+        assert ok is True
+        assert reason is None
+
+    def test_unreachable_returns_false_with_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(*a, **k):
+            raise dbb.psycopg2.OperationalError("connection refused")
+
+        monkeypatch.setattr(dbb.psycopg2, "connect", boom)
+        ok, reason = dbb.postgres_check()
+        assert ok is False
+        assert "connection refused" in reason
+
+
+class TestMySQLCheck:
+    def test_reachable_returns_true_none(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        class FakeConn:
+            def close(self):
+                pass
+
+        monkeypatch.setattr(
+            dbb.mysql.connector, "connect", lambda **k: FakeConn()
+        )
+        ok, reason = dbb.mysql_check()
+        assert ok is True
+        assert reason is None
+
+    def test_unreachable_returns_false_with_reason(self, monkeypatch):
+        from tests import db_bootstrap as dbb
+
+        def boom(**k):
+            raise dbb.mysql.connector.Error("access denied")
+
+        monkeypatch.setattr(dbb.mysql.connector, "connect", boom)
+        ok, reason = dbb.mysql_check()
+        assert ok is False
+        assert "access denied" in reason

--- a/tests/unit/test_dq.py
+++ b/tests/unit/test_dq.py
@@ -191,6 +191,3 @@ class TestDuplicate:
         assert len(dup) == 1
         assert dup[0].result == "pass"
         assert "no exact duplicates" in dup[0].details
-
-
-

--- a/tests/unit/test_explicit_name_flag.py
+++ b/tests/unit/test_explicit_name_flag.py
@@ -64,6 +64,3 @@ def test_single_source_name_backfill_keeps_explicit_name_false(tmp_path: Path) -
     source = loaded.sources[0]
     assert source.name != ""
     assert source._explicit_name is False
-
-
-

--- a/tests/unit/test_schema_drift.py
+++ b/tests/unit/test_schema_drift.py
@@ -78,7 +78,9 @@ class TestToJsonDict:
         current = [("id", "BIGINT")]
         stored = [("id", "INTEGER")]
         d = detect_drift(current, stored).to_json_dict()
-        assert d == {"type_changed": [{"column": "id", "from": "INTEGER", "to": "BIGINT"}]}
+        assert d == {
+            "type_changed": [{"column": "id", "from": "INTEGER", "to": "BIGINT"}]
+        }
 
     def test_all_three_kinds(self):
         current = [("id", "BIGINT"), ("email", "VARCHAR")]

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -418,6 +418,7 @@ class TestCacheWatermarks:
         assert row["last_file_hash"] == "new"
         # Only one row
         import duckdb
+
         con = duckdb.connect(str(sm.path), read_only=True)
         count = con.execute(
             "SELECT COUNT(*) FROM _cache_watermarks WHERE table_name = 't'"
@@ -441,16 +442,14 @@ class TestCacheWatermarks:
         )
         con = duckdb.connect(str(sm.path), read_only=True)
         prod_count = con.execute("SELECT COUNT(*) FROM _watermarks").fetchone()[0]
-        cache_count = con.execute(
-            "SELECT COUNT(*) FROM _cache_watermarks"
-        ).fetchone()[0]
+        cache_count = con.execute("SELECT COUNT(*) FROM _cache_watermarks").fetchone()[
+            0
+        ]
         con.close()
         assert prod_count == 0
         assert cache_count == 1
 
-    def test_write_cache_watermark_normalizes_int_checksum_to_str(
-        self, tmp_path: Path
-    ):
+    def test_write_cache_watermark_normalizes_int_checksum_to_str(self, tmp_path: Path):
         """Pins the documented boundary: int checksums (SQL Server CHECKSUM_AGG)
         are stored as str so the VARCHAR column accepts them uniformly with
         Postgres md5() hex strings."""

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -478,9 +478,7 @@ class TestRebuildMaterializedGold:
         results = rebuild_materialized_gold(con, [t])
         assert results == []
 
-    def test_rebuild_emits_warning_when_join_health_fails(
-        self, tmp_path: Path, caplog
-    ):
+    def test_rebuild_emits_warning_when_join_health_fails(self, tmp_path: Path, caplog):
         """rebuild_materialized_gold runs check_join_health on each rebuilt
         gold; a non-None warning is passed to logger.warning.
         (transforms.py:272)"""

--- a/tests/unit/test_viewer_server.py
+++ b/tests/unit/test_viewer_server.py
@@ -101,7 +101,9 @@ class TestCanBind:
             holder.bind((viewer_server.DEFAULT_HOST, 0))
             holder.listen(1)
             busy_port = holder.getsockname()[1]
-            assert viewer_server._can_bind(viewer_server.DEFAULT_HOST, busy_port) is False
+            assert (
+                viewer_server._can_bind(viewer_server.DEFAULT_HOST, busy_port) is False
+            )
         finally:
             holder.close()
 


### PR DESCRIPTION
## Summary

Auto-create the `feather_test` database on local Postgres & MySQL at pytest session start so DB-gated tests stop silently skipping. Baseline had 16 DB-gated skips (15 Postgres + 1 MySQL) that were hiding test failures and coverage gaps; this branch takes the suite to 808 passed, 0 skipped, 0 failed.

- New `tests/db_bootstrap.py` owns DSN constants, live-reachability probes, per-flavor `CREATE DATABASE IF NOT EXISTS` bootstrap (idempotent — verified by test), a combined `ensure_bootstrap_databases()` entry point, a session-start banner that names the exact `brew services start …` command when a server is down, and `postgres_marker()` / `mysql_marker()` factories for test files.
- `tests/conftest.py` replaces the stale `pg_ctl` `pytest_configure`/`pytest_unconfigure` hooks with a single `pytest_sessionstart` call.
- `tests/unit/sources/test_postgres.py`, `tests/e2e/test_03_discover.py`, and `tests/unit/sources/test_mysql.py` drop their local `_*_available()` probes and DSN constants in favor of the shared module (with `CONN_STR` / `MYSQL_CONN_KWARGS` aliases to avoid churny renames).
- `tests/integration/test_db_bootstrap.py` proves the bootstrap end-to-end against real DBs using a throwaway DB name (`feather_bootstrap_it`) so it never touches `feather_test`.
- `docs/CONTRIBUTING.md` gains a "Local DB prerequisites" section.

## Plan + spec

- Plan: `docs/superpowers/plans/2026-04-21-db-bootstrap-for-tests.md`
- Spec: `docs/superpowers/specs/2026-04-21-db-bootstrap-for-tests-design.md`
- Closes #48

## Test plan

- [x] `uv run pytest -q` → 808 passed, 0 skipped, 0 failed on a healthy local setup.
- [x] `uv run pytest -q 2>&1 | grep -E "(PostgreSQL|MySQL) not available" | wc -l` → 0 (was 16 at baseline).
- [x] `uv run pytest tests/unit/test_db_bootstrap.py -v` → 20 unit tests across 7 classes pass (driver mocks; no real DB).
- [x] `uv run pytest tests/integration/test_db_bootstrap.py -v` → 2 real-DB integration tests pass (throwaway DB dropped in `finally`).
- [x] `uv run ruff check` → clean.
- [x] `uv run ruff format --check .` → clean (pre-push format commit covered 3 new files + 25 pre-existing drifts).
- [ ] **Manual (Task 13 of the plan):** `brew services stop postgresql@17 && uv run pytest -q` → banner appears on stderr naming the brew command, 5 Postgres-gated tests skip with clear reason, exit 0. Then `brew services start postgresql@17` restores to zero skips.

## Known follow-ups (out of scope for this PR)

- Test-data loading for the Postgres `feather_test` DB still requires running `scripts/create_postgres_test_fixture.py` once per fresh machine. This PR makes the DB exist; populating the `erp.*` schema remains a separate dev setup step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)